### PR TITLE
Update/gui/dedup bws and overlay

### DIFF
--- a/src/Field_Selection_GUI.py
+++ b/src/Field_Selection_GUI.py
@@ -253,10 +253,8 @@ class SiteScreen(Screen):
         # Reset values to default
         self.densetc_plot.cf_idx = self.densetc_plot.saved_cf_idx
         self.densetc_plot.thresh_idx = self.densetc_plot.saved_thresh_idx
-        self.densetc_plot.bw10_idx = self.densetc_plot.saved_bw10_idx.copy()
-        self.densetc_plot.bw20_idx = self.densetc_plot.saved_bw20_idx.copy()
-        self.densetc_plot.bw30_idx = self.densetc_plot.saved_bw30_idx.copy()
-        self.densetc_plot.bw40_idx = self.densetc_plot.saved_bw40_idx.copy()
+        self.densetc_plot.bw_idx = {
+            lvl: v.copy() for lvl, v in self.densetc_plot.saved_bw_idx.items()}
         self.densetc_plot.continuous_bw_idx = \
             self.densetc_plot.saved_continuous_bw_idx.copy()
         self.densetc_plot.onset = self.densetc_plot.saved_onset
@@ -358,10 +356,6 @@ class SiteScreen(Screen):
         intensities = self.gui_instance.intensity
 
         # Copy just in case, to prevent any dangling references
-        bw10 = self.densetc_plot.bw10_idx.copy()
-        bw20 = self.densetc_plot.bw20_idx.copy()
-        bw30 = self.densetc_plot.bw30_idx.copy()
-        bw40 = self.densetc_plot.bw40_idx.copy()
         continuous_bw = self.densetc_plot.continuous_bw_idx.copy()
         cf = self.densetc_plot.cf_idx
         thresh = self.densetc_plot.thresh_idx
@@ -374,10 +368,8 @@ class SiteScreen(Screen):
         # Update 'saved' values to current values.
         self.densetc_plot.saved_cf_idx = cf
         self.densetc_plot.saved_thresh_idx = thresh
-        self.densetc_plot.saved_bw10_idx = bw10
-        self.densetc_plot.saved_bw20_idx = bw20
-        self.densetc_plot.saved_bw30_idx = bw30
-        self.densetc_plot.saved_bw40_idx = bw40
+        bw = {lvl: v.copy() for lvl, v in self.densetc_plot.bw_idx.items()}
+        self.densetc_plot.saved_bw_idx = {lvl: v.copy() for lvl, v in bw.items()}
         self.densetc_plot.saved_continuous_bw_idx = continuous_bw
         self.densetc_plot.saved_onset = onset
         self.densetc_plot.saved_peak = peak
@@ -386,30 +378,14 @@ class SiteScreen(Screen):
         self.densetc_plot.saved_marked = marked
 
         # Finish analysis
-        if bw10[0] is not None:
-            bw10_khz = (frequencies[bw10] / 1000).tolist()
-            bw10_octave = afunc.get_bandwidth(*frequencies[bw10]).tolist()
-        else:
-            bw10_khz = [None, None]
-            bw10_octave = None
-        if bw20[0] is not None:
-            bw20_khz = (frequencies[bw20] / 1000).tolist()
-            bw20_octave = afunc.get_bandwidth(*frequencies[bw20]).tolist()
-        else:
-            bw20_khz = [None, None]
-            bw20_octave = None
-        if bw30[0] is not None:
-            bw30_khz = (frequencies[bw30] / 1000).tolist()
-            bw30_octave = afunc.get_bandwidth(*frequencies[bw30]).tolist()
-        else:
-            bw30_khz = [None, None]
-            bw30_octave = None
-        if bw40[0] is not None:
-            bw40_khz = (frequencies[bw40] / 1000).tolist()
-            bw40_octave = afunc.get_bandwidth(*frequencies[bw40]).tolist()
-        else:
-            bw40_khz = [None, None]
-            bw40_octave = None
+        bw_khz, bw_oct = {}, {}
+        for lvl in BW_LEVELS:
+            if bw[lvl][0] is not None:
+                bw_khz[lvl] = (frequencies[bw[lvl]] / 1000).tolist()
+                bw_oct[lvl] = afunc.get_bandwidth(*frequencies[bw[lvl]]).tolist()
+            else:
+                bw_khz[lvl] = [None, None]
+                bw_oct[lvl] = None
 
         if continuous_bw[0] is None:  
             # Site is being saved with new data, but cont. BW's haven't updated
@@ -419,9 +395,10 @@ class SiteScreen(Screen):
                 driven_offset_ms=offset,
                 spont_onset_ms=400 - (offset - onset),
                 spont_offset_ms=400)
-            _, _, cf, thresh, bw10, bw20, bw30, bw40, continuous_bw, _ = \
+            _, _, cf, thresh, *bws, continuous_bw, _ = \
                 afunc.ttest_analyze_tuning_curve(
                      afunc.ttest_driven_vs_spont_tc(*ttest_spike_counts))
+            bw = dict(zip(BW_LEVELS, bws))
         try:  
             # Cont. BW should work now, but rare cases may still create an 
             # exception (eg. no regions found in auto-tc)
@@ -442,35 +419,28 @@ class SiteScreen(Screen):
 
         analysis_id = self.gui_instance.analysis_id
         site_number = self.map_number
+        update_doc = {
+            "cf_khz": cf_khz,
+            "threshold_db": thresh_db,
+            "cf_idx": cf,
+            "threshold_idx": thresh,
+            "continuous_bw_khz": continuous_bw_khz,
+            "continuous_bw_idx": continuous_bw,
+            "continuous_bw_octave": continuous_bw_octave,
+            "onset_ms": onset,
+            "peak_ms": peak,
+            "offset_ms": offset,
+            "peak_driven_rate_hz": peak_driven_rate,
+            "marked": marked,
+        }
+        for lvl in BW_LEVELS:
+            update_doc[f"bw{lvl}_idx"] = bw[lvl]
+            update_doc[f"bw{lvl}_khz"] = bw_khz[lvl]
+            update_doc[f"bw{lvl}_octave"] = bw_oct[lvl]
+
         self.gui_instance.densetc_analysis_collection.update_one(
-            {"analysis_id": analysis_id, 
-             "number": site_number},
-            {"$set": {
-                "cf_khz": cf_khz, 
-                "threshold_db": thresh_db, 
-                "cf_idx": cf,
-                "threshold_idx": thresh,
-                "bw10_khz": bw10_khz, 
-                "bw20_khz": bw20_khz, 
-                "bw30_khz": bw30_khz,
-                "bw40_khz": bw40_khz,
-                "bw10_idx": bw10,
-                "bw20_idx": bw20, 
-                "bw30_idx": bw30,
-                "bw40_idx": bw40,
-                "bw10_octave": bw10_octave,
-                "bw20_octave": bw20_octave,
-                "bw30_octave": bw30_octave, 
-                "bw40_octave": bw40_octave,
-                "continuous_bw_khz": continuous_bw_khz,
-                "continuous_bw_idx": continuous_bw,
-                "continuous_bw_octave": continuous_bw_octave,
-                "onset_ms": onset, 
-                "peak_ms": peak, 
-                "offset_ms": offset,
-                "peak_driven_rate_hz": peak_driven_rate,
-                "marked": marked,
-            }})
+            {"analysis_id": analysis_id, "number": site_number},
+            {"$set": update_doc})
 
         self.gui_instance.analysis_metadata_collection.update_one(
             {"_id": analysis_id},
@@ -490,10 +460,8 @@ class SiteScreen(Screen):
         self.gui_instance.plot_dict[self.map_number].onset = onset
         self.gui_instance.plot_dict[self.map_number].peak = peak
         self.gui_instance.plot_dict[self.map_number].offset = offset
-        self.gui_instance.plot_dict[self.map_number].bw10_idx = bw10
-        self.gui_instance.plot_dict[self.map_number].bw20_idx = bw20
-        self.gui_instance.plot_dict[self.map_number].bw30_idx = bw30
-        self.gui_instance.plot_dict[self.map_number].bw40_idx = bw40
+        self.gui_instance.plot_dict[self.map_number].bw_idx = \
+            {lvl: v.copy() for lvl, v in bw.items()}
         self.gui_instance.plot_dict[self.map_number].bubble_color = \
             self.densetc_plot.bubble_color
         self.gui_instance.plot_dict[self.map_number].lat_color = \
@@ -511,7 +479,7 @@ class SiteScreen(Screen):
             driven_offset_ms=offset,
             spont_onset_ms=400 - (offset - onset),
             spont_offset_ms=400)
-        smooth_tc, _, cf, thresh, bw10, bw20, bw30, bw40, continuous_bw, _ = \
+        smooth_tc, _, cf, thresh, *bws, continuous_bw, _ = \
             afunc.ttest_analyze_tuning_curve(
                 afunc.ttest_driven_vs_spont_tc(*ttest_spike_counts))
 
@@ -519,10 +487,7 @@ class SiteScreen(Screen):
         # Data is NOT saved until user hits 'Save' button
         self.densetc_plot.cf_idx = cf
         self.densetc_plot.thresh_idx = thresh
-        self.densetc_plot.bw10_idx = bw10
-        self.densetc_plot.bw20_idx = bw20
-        self.densetc_plot.bw30_idx = bw30
-        self.densetc_plot.bw40_idx = bw40
+        self.densetc_plot.bw_idx = dict(zip(BW_LEVELS, bws))
         self.densetc_plot.continuous_bw_idx = continuous_bw
         smooth_tc[0 < smooth_tc] = 1
         self.densetc_plot.contour_tc = smooth_tc

--- a/src/Field_Selection_GUI.py
+++ b/src/Field_Selection_GUI.py
@@ -2213,6 +2213,38 @@ class SitePlot(RelativeLayout):
 
         self.bubble.update({"sizes": scaled_s ** 2})
 
+    def _draw_tc_overlays(self, ax, contour_color=None):
+        """
+        Draw CF marker, BW lines/markers, and contour on top of whichever
+        TC rendering (bubble / line / heatmap) just populated `ax`.
+
+        `contour_color` lets the dark-background plots (line, heatmap in
+        detailed view) force a white contour; None uses matplotlib's cycle.
+        """
+        if self.use_bw and (self.cf_idx is not None):
+            for lvl in BW_LEVELS:
+                idx = self.bw_idx[lvl]
+                if idx[0] is None:
+                    continue
+                y = self.thresh_idx + lvl // 5  # assumes 5 dB steps — TODO issue #13
+                self.bw_lines[lvl] = ax.plot(idx, [y, y], "r", lw=1.5)[0]
+                if self.detailed_plot:
+                    self.bw_markers[lvl][0] = ax.plot(
+                        idx[0], y, "rd", ms=8, picker=5)[0]
+                    self.bw_markers[lvl][1] = ax.plot(
+                        idx[1], y, "rd", ms=8, picker=5)[0]
+
+        if self.use_contour:
+            if contour_color:
+                self.contour_line = ax.contour(self.contour_tc, levels=[0],
+                                               colors=contour_color)
+            else:
+                self.contour_line = ax.contour(self.contour_tc, levels=[0])
+
+        if self.cf_idx is not None:
+            self.cf_marker = ax.plot(self.cf_idx, self.thresh_idx,
+                                     "r*", ms=8, alpha=0.5)[0]
+
     def bubble_plot(self, ax=None, x=None, y=None, s=None, color=None, 
                     axis_visible="off", axis_color="xkcd:white"):
         """
@@ -2275,51 +2307,8 @@ class SitePlot(RelativeLayout):
                                  lw=0.5, c=color)
         ax.set_facecolor(axis_color)
 
-        if self.use_bw and (self.cf_idx is not None):
-            # Assumes 5dB step size. Fix if it ever changes
-            bw10_y = self.thresh_idx + 2
-            bw20_y = self.thresh_idx + 4
-            bw30_y = self.thresh_idx + 6
-            bw40_y = self.thresh_idx + 8
-            if self.bw10_idx[0] is not None:
-                self.bw10_line = ax.plot(self.bw10_idx, [bw10_y, bw10_y], 
-                                         "r", lw=1.5)[0]
-                if self.detailed_plot:
-                    self.bw10_markers[0] = ax.plot(self.bw10_idx[0], bw10_y, 
-                                                   "rd", ms=8, picker=5)[0]
-                    self.bw10_markers[1] = ax.plot(self.bw10_idx[1], bw10_y, 
-                                                   "rd", ms=8, picker=5)[0]
-            if self.bw20_idx[0] is not None:
-                self.bw20_line = ax.plot(self.bw20_idx, [bw20_y, bw20_y], 
-                                         "r", lw=1.5)[0]
-                if self.detailed_plot:
-                    self.bw20_markers[0] = ax.plot(self.bw20_idx[0], bw20_y, 
-                                                   "rd", ms=8, picker=5)[0]
-                    self.bw20_markers[1] = ax.plot(self.bw20_idx[1], bw20_y, 
-                                                   "rd", ms=8, picker=5)[0]
-            if self.bw30_idx[0] is not None:
-                self.bw30_line = ax.plot(self.bw30_idx, [bw30_y, bw30_y], 
-                                         "r", lw=1.5)[0]
-                if self.detailed_plot:
-                    self.bw30_markers[0] = ax.plot(self.bw30_idx[0], bw30_y, 
-                                                   "rd", ms=8, picker=5)[0]
-                    self.bw30_markers[1] = ax.plot(self.bw30_idx[1], bw30_y, 
-                                                   "rd", ms=8, picker=5)[0]
-            if self.bw40_idx[0] is not None:
-                self.bw40_line = ax.plot(self.bw40_idx, [bw40_y, bw40_y], 
-                                         "r", lw=1.5)[0]
-                if self.detailed_plot:
-                    self.bw40_markers[0] = ax.plot(self.bw40_idx[0], bw40_y, 
-                                                   "rd", ms=8, picker=5)[0]
-                    self.bw40_markers[1] = ax.plot(self.bw40_idx[1], bw40_y, 
-                                                   "rd", ms=8, picker=5)[0]
+        self._draw_tc_overlays(ax)
 
-        if self.use_contour:
-            self.contour_line = ax.contour(self.contour_tc, levels=[0])
-
-        if self.cf_idx is not None:
-            self.cf_marker = ax.plot(self.cf_idx, self.thresh_idx, 
-                                     "r*", ms=8, alpha=0.5)[0]
         ax.set_xlim([0, self.gui_instance.num_frequency])
         ax.set_ylim([0, self.gui_instance.num_intensity])
         ax.axis(axis_visible)
@@ -2372,55 +2361,9 @@ class SitePlot(RelativeLayout):
         ax.add_collection(self.line)
         ax.set_facecolor(axis_color)
 
-        if self.use_bw and self.cf_idx:
-            # Assumes 5dB step size. Fix if it ever changes
-            bw10_y = self.thresh_idx + 2
-            bw20_y = self.thresh_idx + 4
-            bw30_y = self.thresh_idx + 6
-            bw40_y = self.thresh_idx + 8
-            if self.bw10_idx[0] is not None:
-                self.bw10_line = ax.plot(self.bw10_idx, [bw10_y, bw10_y], 
-                                         "r", lw=1.5)[0]
-                if self.detailed_plot:
-                    self.bw10_markers[0] = ax.plot(self.bw10_idx[0], bw10_y, 
-                                                   "rd", ms=8, picker=5)[0]
-                    self.bw10_markers[1] = ax.plot(self.bw10_idx[1], bw10_y, 
-                                                   "rd", ms=8, picker=5)[0]
-            if self.bw20_idx[0] is not None:
-                self.bw20_line = ax.plot(self.bw20_idx, [bw20_y, bw20_y], 
-                                         "r", lw=1.5)[0]
-                if self.detailed_plot:
-                    self.bw20_markers[0] = ax.plot(self.bw20_idx[0], bw20_y, 
-                                                   "rd", ms=8, picker=5)[0]
-                    self.bw20_markers[1] = ax.plot(self.bw20_idx[1], bw20_y, 
-                                                   "rd", ms=8, picker=5)[0]
-            if self.bw30_idx[0] is not None:
-                self.bw30_line = ax.plot(self.bw30_idx, [bw30_y, bw30_y], 
-                                         "r", lw=1.5)[0]
-                if self.detailed_plot:
-                    self.bw30_markers[0] = ax.plot(self.bw30_idx[0], bw30_y, 
-                                                   "rd", ms=8, picker=5)[0]
-                    self.bw30_markers[1] = ax.plot(self.bw30_idx[1], bw30_y,
-                                                   "rd", ms=8, picker=5)[0]
-            if self.bw40_idx[0] is not None:
-                self.bw40_line = ax.plot(self.bw40_idx, [bw40_y, bw40_y],
-                                         "r", lw=1.5)[0]
-                if self.detailed_plot:
-                    self.bw40_markers[0] = ax.plot(self.bw40_idx[0], bw40_y, 
-                                                   "rd", ms=8, picker=5)[0]
-                    self.bw40_markers[1] = ax.plot(self.bw40_idx[1], bw40_y, 
-                                                   "rd", ms=8, picker=5)[0]
-
-        if self.use_contour:
-            if self.detailed_plot:
-                self.contour_line = ax.contour(self.contour_tc, levels=[0], 
-                                               colors="xkcd:white")
-            else:
-                self.contour_line = ax.contour(self.contour_tc, levels=[0])
-
-        if self.cf_idx:
-            self.cf_marker = ax.plot(self.cf_idx, self.thresh_idx, 
-                                     "r*", ms=8, alpha=1)[0]
+        self._draw_tc_overlays(
+            ax, contour_color="xkcd:white" if self.detailed_plot else None)
+        
         ax.set_xlim([0, self.gui_instance.num_frequency])
         ax.set_ylim([0, self.gui_instance.num_intensity])
         ax.axis(axis_visible)
@@ -2453,55 +2396,9 @@ class SitePlot(RelativeLayout):
         self.heatmap = ax.imshow(tc_image, cmap=self.heatmap_cmap, 
                                  aspect="auto")
 
-        if self.use_bw and self.cf_idx:
-            # TODO Assumes 5dB step size. Fix if it ever changes
-            bw10_y = self.thresh_idx + 2
-            bw20_y = self.thresh_idx + 4
-            bw30_y = self.thresh_idx + 6
-            bw40_y = self.thresh_idx + 8
-            if self.bw10_idx[0] is not None:
-                self.bw10_line = ax.plot(self.bw10_idx, [bw10_y, bw10_y], 
-                                         "r", lw=1.5)[0]
-                if self.detailed_plot:
-                    self.bw10_markers[0] = ax.plot(self.bw10_idx[0], bw10_y, 
-                                                   "rd", ms=8, picker=5)[0]
-                    self.bw10_markers[1] = ax.plot(self.bw10_idx[1], bw10_y, 
-                                                   "rd", ms=8, picker=5)[0]
-            if self.bw20_idx[0] is not None:
-                self.bw20_line = ax.plot(self.bw20_idx, [bw20_y, bw20_y], 
-                                         "r", lw=1.5)[0]
-                if self.detailed_plot:
-                    self.bw20_markers[0] = ax.plot(self.bw20_idx[0], bw20_y, 
-                                                   "rd", ms=8, picker=5)[0]
-                    self.bw20_markers[1] = ax.plot(self.bw20_idx[1], bw20_y, 
-                                                   "rd", ms=8, picker=5)[0]
-            if self.bw30_idx[0] is not None:
-                self.bw30_line = ax.plot(self.bw30_idx, [bw30_y, bw30_y], 
-                                         "r", lw=1.5)[0]
-                if self.detailed_plot:
-                    self.bw30_markers[0] = ax.plot(self.bw30_idx[0], bw30_y, 
-                                                   "rd", ms=8, picker=5)[0]
-                    self.bw30_markers[1] = ax.plot(self.bw30_idx[1], bw30_y, 
-                                                   "rd", ms=8, picker=5)[0]
-            if self.bw40_idx[0] is not None:
-                self.bw40_line = ax.plot(self.bw40_idx, [bw40_y, bw40_y], 
-                                         "r", lw=1.5)[0]
-                if self.detailed_plot:
-                    self.bw40_markers[0] = ax.plot(self.bw40_idx[0], bw40_y, 
-                                                   "rd", ms=8, picker=5)[0]
-                    self.bw40_markers[1] = ax.plot(self.bw40_idx[1], bw40_y, 
-                                                   "rd", ms=8, picker=5)[0]
-
-        if self.use_contour:
-            if self.detailed_plot:
-                self.contour_line = ax.contour(self.contour_tc, levels=[0], 
-                                               colors="xkcd:white")
-            else:
-                self.contour_line = ax.contour(self.contour_tc, levels=[0])
-
-        if self.cf_idx:
-            self.cf_marker = ax.plot(self.cf_idx, self.thresh_idx, 
-                                     "r*", ms=8, alpha=1)[0]
+        self._draw_tc_overlays(
+            ax, contour_color="xkcd:white" if self.detailed_plot else None)
+        
         ax.set_xlim([0, self.gui_instance.num_frequency-1])
         ax.set_ylim([0, self.gui_instance.num_intensity-1])
         ax.axis(axis_visible)

--- a/src/Field_Selection_GUI.py
+++ b/src/Field_Selection_GUI.py
@@ -37,6 +37,11 @@ from matplotlib.collections import LineCollection
 import warnings
 from matplotlib.axes._axes import _log as matplotlib_axes_logger
 
+# dB-above-threshold levels at which bandwidths are measured. The y-offset
+# on the TC plot for each is level // intensity_step (currently 5 dB steps,
+# so BW10 sits 2 rows above threshold, BW20 sits 4 rows above, etc.).
+BW_LEVELS = (10, 20, 30, 40)
+
 # Ignore warnings about opening too many figures or not finding contour lines 
 # issued by matplotlib
 warnings.filterwarnings("ignore", module="matplotlib")
@@ -1802,14 +1807,10 @@ class SitePlot(RelativeLayout):
         self.peak_driven_rate = self.site_analysis["peak_driven_rate_hz"]
         self.saved_peak_driven_rate = self.site_analysis["peak_driven_rate_hz"]
         self.spont_rate = self.site_analysis["spont_firing_rate_hz"]
-        self.bw10_idx = self.site_analysis["bw10_idx"].copy()
-        self.saved_bw10_idx = self.site_analysis["bw10_idx"].copy()
-        self.bw20_idx = self.site_analysis["bw20_idx"].copy()
-        self.saved_bw20_idx = self.site_analysis["bw20_idx"].copy()
-        self.bw30_idx = self.site_analysis["bw30_idx"].copy()
-        self.saved_bw30_idx = self.site_analysis["bw30_idx"].copy()
-        self.bw40_idx = self.site_analysis["bw40_idx"].copy()
-        self.saved_bw40_idx = self.site_analysis["bw40_idx"].copy()
+        self.bw_idx = {lvl: self.site_analysis[f"bw{lvl}_idx"].copy()
+                       for lvl in BW_LEVELS}
+        self.saved_bw_idx = {lvl: self.site_analysis[f"bw{lvl}_idx"].copy()
+                             for lvl in BW_LEVELS}
         self.continuous_bw_idx = self.site_analysis["continuous_bw_idx"].copy()
         self.saved_continuous_bw_idx = self.site_analysis["continuous_bw_idx"].copy()
         try:
@@ -1839,18 +1840,9 @@ class SitePlot(RelativeLayout):
         self.use_lineplot = False
         self.use_heatmap = False
         self.cf_marker = None
-        self.bw10_line = None
-        self.bw20_line = None
-        self.bw30_line = None
-        self.bw40_line = None
-        self.bw10_markers = [None, None]
-        self.bw20_markers = [None, None]
-        self.bw30_markers = [None, None]
-        self.bw40_markers = [None, None]
-        self.bw10_press = [0, 0]
-        self.bw20_press = [0, 0]
-        self.bw30_press = [0, 0]
-        self.bw40_press = [0, 0]
+        self.bw_lines = {lvl: None for lvl in BW_LEVELS}
+        self.bw_markers = {lvl: [None, None] for lvl in BW_LEVELS}
+        self.bw_press = {lvl: [False, False] for lvl in BW_LEVELS}
         self.contour_line = None
         self.picking_cf = False
         self.picking_bw = False
@@ -2653,33 +2645,18 @@ class SitePlot(RelativeLayout):
         else:
             self.cf_marker.set_xdata(self.cf_idx)
             self.cf_marker.set_ydata(self.thresh_idx)
-        # Ensure all BWs are set correctly. If BW exceeds range, set to None. 
-        # If setting new BW (was previously None, but now should exist with new
-        # threshold), set to very wide default range across available frequency
-        # range
-        # Assumes 5dB step size. Fix if it ever changes
         freq_range = self.gui_instance.num_frequency
         int_range = self.gui_instance.num_intensity
-        if (self.thresh_idx + 2) <= int_range:
-            if self.bw10_idx[0] is None:
-                self.bw10_idx = [10, freq_range - 10]
-        else:
-            self.bw10_idx = [None, None]
-        if (self.thresh_idx + 4) <= int_range:
-            if self.bw20_idx[0] is None:
-                self.bw20_idx = [10, freq_range - 10]
-        else:
-            self.bw20_idx = [None, None]
-        if (self.thresh_idx + 6) <= int_range:
-            if self.bw30_idx[0] is None:
-                self.bw30_idx = [10, freq_range - 10]
-        else:
-            self.bw30_idx = [None, None]
-        if (self.thresh_idx + 8) <= int_range:
-            if self.bw40_idx[0] is None:
-                self.bw40_idx = [10, freq_range - 10]
-        else:
-            self.bw40_idx = [None, None]
+        # Any BW whose row now sits above the intensity grid is cleared;
+        # any that's newly in-range but was previously absent gets a wide
+        # default so the user has handles to drag.
+        for lvl in BW_LEVELS:
+            row = self.thresh_idx + lvl // 5  # assumes 5 dB steps — TODO issue #13
+            if row <= int_range:
+                if self.bw_idx[lvl][0] is None:
+                    self.bw_idx[lvl] = [10, freq_range - 10]
+            else:
+                self.bw_idx[lvl] = [None, None]
 
         # Un-flag picking_cf
         self.picking_cf = False
@@ -2695,189 +2672,57 @@ class SitePlot(RelativeLayout):
         lines.
         """
         # TODO currently doesn't do anything to continuous_bw
-        if self.bw10_markers[0] is not None:
-            if self.bw10_markers[0].contains(event)[0]:
-                self.bw_pressed = True
-                self.bw10_markers[0].set_ms(12)
-                self.bw10_press[0] = 1
-                event.canvas.draw()
-            elif self.bw10_markers[1].contains(event)[0]:
-                self.bw_pressed = True
-                self.bw10_markers[1].set_ms(12)
-                self.bw10_press[1] = 1
-                event.canvas.draw()
-        if self.bw20_markers[0] is not None:
-            if self.bw20_markers[0].contains(event)[0]:
-                self.bw_pressed = True
-                self.bw20_markers[0].set_ms(12)
-                self.bw20_press[0] = 1
-                event.canvas.draw()
-            elif self.bw20_markers[1].contains(event)[0]:
-                self.bw_pressed = True
-                self.bw20_markers[1].set_ms(12)
-                self.bw20_press[1] = 1
-                event.canvas.draw()
-        if self.bw30_markers[0] is not None:
-            if self.bw30_markers[0].contains(event)[0]:
-                self.bw_pressed = True
-                self.bw30_markers[0].set_ms(12)
-                self.bw30_press[0] = 1
-                event.canvas.draw()
-            elif self.bw30_markers[1].contains(event)[0]:
-                self.bw_pressed = True
-                self.bw30_markers[1].set_ms(12)
-                self.bw30_press[1] = 1
-                event.canvas.draw()
-        if self.bw40_markers[0] is not None:
-            if self.bw40_markers[0].contains(event)[0]:
-                self.bw_pressed = True
-                self.bw40_markers[0].set_ms(12)
-                self.bw40_press[0] = 1
-                event.canvas.draw()
-            elif self.bw40_markers[1].contains(event)[0]:
-                self.bw_pressed = True
-                self.bw40_markers[1].set_ms(12)
-                self.bw40_press[1] = 1
-                event.canvas.draw()
+        for lvl in BW_LEVELS:
+            markers = self.bw_markers[lvl]
+            if markers[0] is None:
+                continue
+            for side in (0, 1):
+                if markers[side].contains(event)[0]:
+                    self.bw_pressed = True
+                    markers[side].set_ms(12)
+                    self.bw_press[lvl][side] = True
+                    event.canvas.draw()
+                    return  # one marker at a time
 
     def move_bw(self, event_x, event_y):
-        """Ongoing UX for user updating bandwidth."""
-        # Must transform into axes user data coordinates (xlim, ylim) in order 
-        # to move line to appropriate x-coordinate based on mouse position
+        """
+        Drag the currently-held BW marker, clamped to [0, max_freq_idx] and
+        prevented from crossing its partner.
+        """
         ax_inv = self.ax[1].transData.inverted()
-        xdata, ydata = ax_inv.transform((event_x, event_y))
+        xdata, _ = ax_inv.transform((event_x, event_y))
         if xdata is None:
             return
+        max_idx = self.gui_instance.num_frequency - 1
 
-        if self.bw10_press[0]:
-            if xdata < self.bw10_markers[1].get_xdata():
-                # Don't allow markers to cross each other
-                if xdata >= 0:
-                    # Limit BW to lowest frequency (index 0)
-                    x = int(round(xdata))
-                else:
-                    x = 0
-                self.bw10_markers[0].set_xdata(x)
-                self.bw10_idx[0] = x
-                self.bw10_line.set_xdata(self.bw10_idx)
+        for lvl in BW_LEVELS:
+            press = self.bw_press[lvl]
+            markers = self.bw_markers[lvl]
+            idx = self.bw_idx[lvl]
+            if press[0] and xdata < markers[1].get_xdata()[0]:
+                x = max(0, int(round(xdata)))
+                markers[0].set_xdata([x])
+                idx[0] = x
+                self.bw_lines[lvl].set_xdata(idx)
                 if self.detailed_plot:
                     self.on_changes_signal.send()
-        if self.bw10_press[1]:
-            if xdata > self.bw10_markers[0].get_xdata():
-                # Don't allow markers to cross each other
-                if xdata <= (self.gui_instance.num_frequency - 1):
-                    # Limit BW to highest frequency (max index)
-                    x = int(round(xdata))
-                else:
-                    x = self.gui_instance.num_frequency - 1
-                self.bw10_markers[1].set_xdata(x)
-                self.bw10_idx[1] = x
-                self.bw10_line.set_xdata(self.bw10_idx)
+            elif press[1] and xdata > markers[0].get_xdata()[0]:
+                x = min(max_idx, int(round(xdata)))
+                markers[1].set_xdata([x])
+                idx[1] = x
+                self.bw_lines[lvl].set_xdata(idx)
                 if self.detailed_plot:
                     self.on_changes_signal.send()
-
-        if self.bw20_press[0]:
-            if xdata < self.bw20_markers[1].get_xdata():
-                # Don't allow markers to cross each other
-                if xdata >= 0:
-                    # Limit BW to lowest frequency (index 0)
-                    x = int(round(xdata))
-                else:
-                    x = 0
-                self.bw20_markers[0].set_xdata(x)
-                self.bw20_idx[0] = x
-                self.bw20_line.set_xdata(self.bw20_idx)
-                if self.detailed_plot:
-                    self.on_changes_signal.send()
-        if self.bw20_press[1]:
-            if xdata > self.bw20_markers[0].get_xdata():
-                # Don't allow markers to cross each other
-                if xdata <= (self.gui_instance.num_frequency - 1):
-                    # Limit BW to highest frequency (max index)
-                    x = int(round(xdata))
-                else:
-                    x = self.gui_instance.num_frequency - 1
-                self.bw20_markers[1].set_xdata(x)
-                self.bw20_idx[1] = x
-                self.bw20_line.set_xdata(self.bw20_idx)
-                if self.detailed_plot:
-                    self.on_changes_signal.send()
-
-        if self.bw30_press[0]:
-            if xdata < self.bw30_markers[1].get_xdata():
-                # Don't allow markers to cross each other
-                if xdata >= 0:
-                    # Limit BW to lowest frequency (index 0)
-                    x = int(round(xdata))
-                else:
-                    x = 0
-                self.bw30_markers[0].set_xdata(x)
-                self.bw30_idx[0] = x
-                self.bw30_line.set_xdata(self.bw30_idx)
-                if self.detailed_plot:
-                    self.on_changes_signal.send()
-        if self.bw30_press[1]:
-            if xdata > self.bw30_markers[0].get_xdata():
-                # Don't allow markers to cross each other
-                if xdata <= (self.gui_instance.num_frequency - 1):
-                    # Limit BW to highest frequency (max index)
-                    x = int(round(xdata))
-                else:
-                    x = self.gui_instance.num_frequency - 1
-                self.bw30_markers[1].set_xdata(x)
-                self.bw30_idx[1] = x
-                self.bw30_line.set_xdata(self.bw30_idx)
-                if self.detailed_plot:
-                    self.on_changes_signal.send()
-
-        if self.bw40_press[0]:
-            if xdata < self.bw40_markers[1].get_xdata():
-                # Don't allow markers to cross each other
-                if xdata >= 0:
-                    # Limit BW to lowest frequency (index 0)
-                    x = int(round(xdata))
-                else:
-                    x = 0
-                self.bw40_markers[0].set_xdata(x)
-                self.bw40_idx[0] = x
-                self.bw40_line.set_xdata(self.bw40_idx)
-                if self.detailed_plot:
-                    self.on_changes_signal.send()
-        if self.bw40_press[1]:
-            if xdata > self.bw40_markers[0].get_xdata():
-                # Don't allow markers to cross each other
-                if xdata <= (self.gui_instance.num_frequency - 1):
-                    # Limit BW to highest frequency (max index)
-                    x = int(round(xdata))
-                else:
-                    x = self.gui_instance.num_frequency - 1
-                self.bw40_markers[1].set_xdata(x)
-                self.bw40_idx[1] = x
-                self.bw40_line.set_xdata(self.bw40_idx)
-                if self.detailed_plot:
-                    self.on_changes_signal.send()
-
         self.figure_canvas.draw()
 
     def off_bw(self):
         """Final UX for user updating bandwidth."""
-        self.bw10_press = [0, 0]
-        self.bw20_press = [0, 0]
-        self.bw30_press = [0, 0]
-        self.bw40_press = [0, 0]
-        if self.bw10_markers[0] is not None:
-            self.bw10_markers[0].set_ms(8)
-            self.bw10_markers[1].set_ms(8)
-        if self.bw20_markers[0] is not None:
-            self.bw20_markers[0].set_ms(8)
-            self.bw20_markers[1].set_ms(8)
-        if self.bw30_markers[0] is not None:
-            self.bw30_markers[0].set_ms(8)
-            self.bw30_markers[1].set_ms(8)
-        if self.bw40_markers[0] is not None:
-            self.bw40_markers[0].set_ms(8)
-            self.bw40_markers[1].set_ms(8)
-
+        self.bw_pressed = False
+        for lvl in BW_LEVELS:
+            self.bw_press[lvl] = [False, False]
+            if self.bw_markers[lvl][0] is not None:
+                self.bw_markers[lvl][0].set_ms(8)
+                self.bw_markers[lvl][1].set_ms(8)
         self.figure_canvas.draw()
 
 class InfoPopup(Popup):


### PR DESCRIPTION
The four bandwidth levels are treated identically everywhere; the only thing that varies is the number. Replacing four parallel attributes with one dict keyed by level turns every 4×/8× block into a loop.

Closely related is the repeated logic of drawing BW, contours, and CF marker in the different plot types, which is now extracted to a single helper function.

Closes #3 and #5 