### PR TITLE
Fix/bug bundle

### DIFF
--- a/src/Field_Selection_GUI.py
+++ b/src/Field_Selection_GUI.py
@@ -2092,7 +2092,8 @@ class SitePlot(RelativeLayout):
             # Thrown if s contains no values (non-responsive site)
             scaled_s = s
 
-        self.bubble.update({"offsets": list(zip(x, y)), "sizes": scaled_s ** 2})
+        offsets = np.column_stack((x, y))
+        self.bubble.update({"offsets": offsets, "sizes": scaled_s ** 2})
 
     def update_bubble_size(self):
         """

--- a/src/Field_Selection_GUI.py
+++ b/src/Field_Selection_GUI.py
@@ -2206,7 +2206,7 @@ class SitePlot(RelativeLayout):
             # Thrown if s contains no values (non-responsive site)
             scaled_s = s
         self.bubble = ax.scatter(x=x, y=y, s=scaled_s ** 2, edgecolors="black",
-                                 lw=0.5, c=color)
+                                 lw=0.5, color=color)
         ax.set_facecolor(axis_color)
 
         self._draw_tc_overlays(ax)

--- a/src/map_analysis.py
+++ b/src/map_analysis.py
@@ -172,7 +172,8 @@ if __name__ == "__main__":
                       Style.RESET_ALL)
                 continue
             while (yes_or_no := input("Do you want an SDF calculated for each "
-                                      "tuning curve PSTH [y/n]? (slower) > ")):
+                                      "tuning curve PSTH [y/n]? (slower) > ")
+                .strip().lower()) not in ("y", "n"):
                 continue
             return_sdf = True if yes_or_no == "y" else False
             file = afunc.get_file(title="Select final file", 


### PR DESCRIPTION
- Guard empty bubble offsets using `np.column_stack((x,y))`, resolves #16 
- Change `ax.scatter` to proper color keyword argument, removing flood of user warnings
- Fix infinite CLI `g` loop asking about generation of SDFs, resolves #21 