### PR TITLE
Replace tinymongo with a thin tinydb adapter layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,6 @@ At Anaconda prompt:
 
 Hopefully that works for you without error. I can't predict the future though. Good luck, cadet.
 
-#### tinymongo_fix
-Not an install, just a tweak to the [tinymongo](https://github.com/schapman1974/tinymongo) package after an update broke the thing. It's no longer a maintained package, but this program uses it, so.
-
-Just leave the `tinymongo_fix` folder in the `src` dir, and if you ever feel like writing/changing code that uses it, do:
-
-`from tinymongo_fix.tinymongo_fix import TinyMongoClient`
-
 ### Special note about Kivy
 Kivy is a GUI framework for python. GUIs in python are hard. GUIs are hard in general, but in python they are very hard. This map program is an especially weird GUI. Most people making GUIs don't want/need to do what I did. Kivy was the only python GUI framework I found at the time of creation that allowed me to make a bunch of plots for mapping sites in a way that was functional.
 

--- a/src/Field_Selection_GUI.py
+++ b/src/Field_Selection_GUI.py
@@ -38,12 +38,12 @@ import logging
 from kivy.uix.slider import Slider
 import analysis_functions as afunc
 import blinker
-from tinymongo_fix.tinymongo_fix import TinyMongoClient
 from sklearn.preprocessing import minmax_scale
 from collections import namedtuple
 from matplotlib.collections import LineCollection
 import warnings
 from matplotlib.axes._axes import _log as matplotlib_axes_logger
+from db_adapter import JSONStore
 
 # dB-above-threshold levels at which bandwidths are measured. The y-offset
 # on the TC plot for each is level // intensity_step (currently 5 dB steps,
@@ -588,7 +588,6 @@ class FieldSelectionGUI(BoxLayout):
         self.densetc_data = None
         self.densetc_analysis = None
 
-        self.mongo_connection = None
         self.counter = 0
         self.site_screens = {}
 
@@ -817,11 +816,7 @@ class FieldSelectionGUI(BoxLayout):
             is_ic = self.ic_bool
 
             # --- DB connection & collection handles ------------------
-            self.mongo_connection = TinyMongoClient(
-                os.path.dirname(self._db_path))
-            self.subject_database = getattr(
-                self.mongo_connection,
-                os.path.splitext(os.path.basename(self._db_path))[0])
+            self.subject_database = JSONStore(self._db_path)
             self.map_metadata_collection = self.subject_database.metadata
             self.map_metadata = self.map_metadata_collection.find_one({})
             self.analysis_metadata_collection = \
@@ -847,13 +842,10 @@ class FieldSelectionGUI(BoxLayout):
 
             # --- Project configuration -------------------------------
             # Expect exactly one analysis metadata doc to carry a
-            # configuration (the auto-analysis run). $exists is what we
-            # want but tinymongo doesn't implement it; $ne against a
-            # value the field never holds is a cheap substitute -- any
-            # doc with the field matches, any doc without is skipped.
+            # configuration (the auto-analysis run).
             self.project_configuration = \
                 self.analysis_metadata_collection.find_one(
-                    {"configuration": {"$ne": False}})["configuration"]
+                    {"configuration": {"$exists": True}})["configuration"]
             self.frequency = np.sort(
                 self.project_configuration["densetc_frequency_hz"])
             self.intensity = np.sort(

--- a/src/analysis_functions.py
+++ b/src/analysis_functions.py
@@ -21,13 +21,13 @@ import uuid
 import colorama
 import datetime
 import os
-from tinymongo_fix.tinymongo_fix import TinyMongoClient
 from shapely.geometry import Point
 import voronoi_picker
 from scipy.spatial import Voronoi
 from scipy.stats import ttest_ind
 import colorama
 from colorama import Fore, Style
+from db_adapter import JSONStore
 
 
 def get_folder(**kwargs):
@@ -481,7 +481,7 @@ def load_analysis(analysis_metadata_collection):
     """
     Load menu allowing user to choose existing analysis or create a new one.
     
-    Takes a tinymongo collection as input.
+    Takes a tinydb "mongo" collection as input.
     Frozen analyses cannot be loaded from this function.
     
     Returns a pandas Series of analysis metadata (or None if user exits menu),
@@ -579,7 +579,7 @@ def create_new_densetc_analysis(template_id, new_metadata,
     Adds metadata and duplicates entries from an existing analysis.
     
     Expects a dictionary of new analysis metadata and the analysis metadata and
-      densetc_analysis tinymongo collections to update. Duplicates existing 
+      densetc_analysis tinydb "mongo" collections to update. Duplicates existing 
       analysis and replaces id with new analysis id.
       
     Returns new analysis_metadata _id.
@@ -1376,10 +1376,9 @@ def create_final_file(ic_bool=False):
     # style, but arbitrary
     array_length = 88
 
-    # Initialize tinymongo database
-    mongo_connection = TinyMongoClient(os.path.dirname(db_path))
-    subject_database = getattr(mongo_connection, 
-                               os.path.splitext(os.path.basename(db_path))[0])
+    # Initialize database
+    subject_database = JSONStore(db_path)
+
     if ic_bool:
         densetc_analysis_collection = subject_database.densetc_IC_analysis
     else:

--- a/src/db_adapter.py
+++ b/src/db_adapter.py
@@ -16,12 +16,19 @@ Supported:
     coll.find_one({"configuration": {"$exists": True}})
     coll.update_one({"_id": x}, {"$set": {...}})
 
-Not supported: insert, delete, $gt/$lt/$in/$ne, nested paths, projections, sort.
+Not supported: delete, $gt/$lt/$in/$ne, nested paths, projections, sort.
 Add them if something new needs them.
 """
 from functools import reduce
 from tinydb import TinyDB, Query
+from uuid import uuid4
+from copy import deepcopy
+from dataclasses import dataclass
 
+
+@dataclass(frozen=True)
+class InsertOneResult:
+    inserted_id: str
 
 class JSONStore:
     def __init__(self, path):
@@ -55,6 +62,15 @@ class Collection:
         if not query:
             raise ValueError("find_one() requires a non-empty filter")
         return self._table.get(_build_query(query))
+    
+    def insert_one(self, document):
+        if not isinstance(document, dict):
+            raise TypeError("insert_one() requires a dict document")
+
+        doc = deepcopy(document)
+        doc.setdefault("_id", str(uuid4())) # preserve tinymongo behavior
+        self._table.insert(doc)
+        return InsertOneResult(doc["_id"])
 
     def update_one(self, filter_, update):
         if set(update) != {"$set"}:

--- a/src/db_adapter.py
+++ b/src/db_adapter.py
@@ -24,6 +24,7 @@ from tinydb import TinyDB, Query
 from uuid import uuid4
 from copy import deepcopy
 from dataclasses import dataclass
+from pathlib import Path
 
 
 @dataclass(frozen=True)
@@ -40,6 +41,11 @@ class JSONStore:
     def __init__(self, path):
         # Unlike TinyMongoClient, which took a directory and derived the
         # filename from the "database" name, we just take the full path.
+        # Adds `.json` extension if it's missing, since this is just a
+        # simple adapter layer for old tinymongo json files
+        path = Path(path)
+        if not path.suffix:
+            path = path.with_suffix(".json")
         self._db = TinyDB(str(path))
 
     def collection(self, name):

--- a/src/db_adapter.py
+++ b/src/db_adapter.py
@@ -1,0 +1,97 @@
+# db_adapter.py
+"""
+Drop-in replacement for the subset of tinymongo this app uses.
+
+Tinymongo was a thin wrapper over TinyDB, so the on-disk format is just a
+TinyDB database with one table per collection. We use TinyDB directly and
+recreate only the mongo-ish surface area we actually call. Existing JSON
+files open unmodified; writes go to the same format.
+
+Supported:
+    db = JSONStore("/path/to/subject.json")
+    coll = db.sites                                    # or db.collection("sites")
+    coll.find({})                                      # all docs
+    coll.find({"analysis_id": x, "number": 3})         # equality filter(s), AND-ed
+    coll.find_one({...})                               # first match or None
+    coll.find_one({"configuration": {"$exists": True}})
+    coll.update_one({"_id": x}, {"$set": {...}})
+
+Not supported: insert, delete, $gt/$lt/$in/$ne, nested paths, projections, sort.
+Add them if something new needs them.
+"""
+from functools import reduce
+from tinydb import TinyDB, Query
+
+
+class JSONStore:
+    def __init__(self, path):
+        # Unlike TinyMongoClient, which took a directory and derived the
+        # filename from the "database" name, we just take the full path.
+        self._db = TinyDB(str(path))
+
+    def collection(self, name):
+        return Collection(self._db.table(name))
+
+    def __getattr__(self, name):
+        # `db.sites` → collection("sites"), same as tinymongo's attr access.
+        # __getattr__ only fires for missing attrs so .close() etc. aren't
+        # shadowed.
+        return self.collection(name)
+
+    def close(self):
+        self._db.close()
+
+
+class Collection:
+    def __init__(self, table):
+        self._table = table
+
+    def find(self, query=None):
+        if not query:
+            return self._table.all()
+        return self._table.search(_build_query(query))
+
+    def find_one(self, query=None):
+        if not query:
+            raise ValueError("find_one() requires a non-empty filter")
+        return self._table.get(_build_query(query))
+
+    def update_one(self, filter_, update):
+        if set(update) != {"$set"}:
+            raise NotImplementedError(
+                f"Only $set is supported, got {set(update)}")
+        if not filter_:
+            raise ValueError("update_one() requires a non-empty filter")
+        # Update at most one document even if the filter matches several. 
+        doc = self._table.get(_build_query(filter_))
+        if doc is not None:
+            self._table.update(update["$set"], doc_ids=[doc.doc_id])
+
+
+def _build_query(mongo_query):
+    """
+    Translate a flat mongo-style filter to a TinyDB Query. Fields AND together.
+    """
+    if not mongo_query:
+        raise ValueError("_build_query() requires a non-empty filter")
+    Q = Query()
+    clauses = []
+    for field, val in mongo_query.items():
+        if "." in field:
+            raise NotImplementedError(
+                f"Nested field paths are not supported: {field!r}"
+            )
+        if isinstance(val, dict):
+            if len(val) != 1:
+                raise NotImplementedError(
+                    f"Only one operator per field is supported, got {val!r}"
+                )
+            op, arg = next(iter(val.items()))
+            if op == "$exists":
+                clauses.append(Q[field].exists() if arg
+                               else ~Q[field].exists())
+            else:
+                raise NotImplementedError(f"Operator {op}")
+        else:
+            clauses.append(Q[field] == val)
+    return reduce(lambda a, b: a & b, clauses)

--- a/src/db_adapter.py
+++ b/src/db_adapter.py
@@ -30,6 +30,12 @@ from dataclasses import dataclass
 class InsertOneResult:
     inserted_id: str
 
+
+@dataclass(frozen=True)
+class InsertManyResult:
+    inserted_ids: list[str]
+
+
 class JSONStore:
     def __init__(self, path):
         # Unlike TinyMongoClient, which took a directory and derived the
@@ -71,6 +77,24 @@ class Collection:
         doc.setdefault("_id", str(uuid4())) # preserve tinymongo behavior
         self._table.insert(doc)
         return InsertOneResult(doc["_id"])
+    
+    def insert_many(self, documents):
+        docs = list(documents)
+        if not all(isinstance(doc, dict) for doc in docs):
+            raise TypeError("insert_many() requires an iterable of dict documents")
+
+        inserted_ids = []
+        to_insert = []
+        for document in docs:
+            doc = deepcopy(document)
+            doc.setdefault("_id", str(uuid4())) # preserve tinymongo behavior
+            inserted_ids.append(doc["_id"])
+            to_insert.append(doc)
+
+        if to_insert:
+            self._table.insert_multiple(to_insert)
+
+        return InsertManyResult(inserted_ids)
 
     def update_one(self, filter_, update):
         if set(update) != {"$set"}:

--- a/src/densetc_analysis.py
+++ b/src/densetc_analysis.py
@@ -7,12 +7,12 @@ from neo.io.brainwaref32io import BrainwareF32IO
 import pandas as pd
 from skimage.measure import label, regionprops
 import matplotlib.pyplot as plt
-from tinymongo_fix.tinymongo_fix import TinyMongoClient
 import datetime
 from colorama import Fore, Style
 import bayesian_bins as bb
 import analysis_functions as afunc
 from functools import partial
+from db_adapter import JSONStore
 
 os.environ["RAY_DEDUP_LOGS"] = "0"
 import ray
@@ -76,13 +76,8 @@ def run_program(config_dict, version, final_file=None, return_sdf=True):
     # This will combine data/analysis if a database already exists.
     # That is probably not what you want. Recommend moving or deleting any
     # previous database files for the subject.
-    connection = TinyMongoClient(save_dir_path + subject_name)
-
-    # Grab database that was just created.
-    # getattr result is same as eg. connection.RAT1 if subject_name == RAT1
-    # Also, connection.RAT1.1 (with a decimal) is normally invalid syntax, 
-    # but using getattr() and passing "RAT1.1" works as expected.
-    db = getattr(connection, subject_name)
+    # TODO make that a real failure, or ask to overwrite
+    db = JSONStore(save_dir_path + subject_name)
 
     # Generate db collections
     db_metadata = db.metadata
@@ -404,6 +399,8 @@ def run_program(config_dict, version, final_file=None, return_sdf=True):
         db_noiseburst_data.insert_many(burst_data_list)
         if ic_bool:
             db_noiseburst_IC_data.insert_many(burst_IC_data_list)
+
+    db.close()
 
 
 def densetc_bw_loop(idx, file, total, use_f32, n_sweeps, freqs, ints, 

--- a/src/map_analysis.py
+++ b/src/map_analysis.py
@@ -8,12 +8,12 @@ import tkinter
 import subprocess
 import analysis_functions as afunc
 import densetc_analysis
-from tinymongo_fix.tinymongo_fix import TinyMongoClient
 import colorama
 from colorama import Fore, Style, Back
 import logging
 import json
 import pandas as pd
+from db_adapter import JSONStore
 
 
 colorama.init()
@@ -39,9 +39,7 @@ def _pick_map_and_analysis():
     if not db_path:
         return None
 
-    conn = TinyMongoClient(os.path.dirname(db_path))
-    db = getattr(conn,
-                 os.path.splitext(os.path.basename(db_path))[0])
+    db = JSONStore(db_path)
     meta_coll = db.analysis_metadata
 
     selection, create_new = afunc.load_analysis(meta_coll)

--- a/src/tinymongo_fix/README.md
+++ b/src/tinymongo_fix/README.md
@@ -1,7 +1,0 @@
-tinymongo is integrated into the data solution of this program, but it is no longer maintained and a tweak in another package broke it on later versions of Python.
-
-This 'package' fixes the problem so that the program can continue to use tinymongo normally.
-
-Any time you would use TinyMongoClient, import this version and use its TinyMongoClient instead.
-
-See https://github.com/schapman1974/tinymongo/issues/58

--- a/src/tinymongo_fix/tinymongo_fix.py
+++ b/src/tinymongo_fix/tinymongo_fix.py
@@ -1,7 +1,0 @@
-import tinydb
-import tinymongo
-
-class TinyMongoClient(tinymongo.TinyMongoClient):
-    @property
-    def _storage(self):
-        return tinydb.storages.JSONStorage


### PR DESCRIPTION
tinymongo is no longer maintained and does not work out of the box anymore. A patch was made for this repo to allow it to work, but it's better to simply remove the dependency altogether.

A thin TinyDB adapter layer allows almost all of the code to remain the same and retain the same functionality, and removes the stale dependency and fragile workaround. A full overhaul of the data architecture is warranted, but backwards compatibility is a necessity in the short-term.

Resolves #8 