### PR TITLE
Allow easy pulling of doc from singleton collection in db_adapter

### DIFF
--- a/src/Field_Selection_GUI.py
+++ b/src/Field_Selection_GUI.py
@@ -818,7 +818,7 @@ class FieldSelectionGUI(BoxLayout):
             # --- DB connection & collection handles ------------------
             self.subject_database = JSONStore(self._db_path)
             self.map_metadata_collection = self.subject_database.metadata
-            self.map_metadata = self.map_metadata_collection.find_one({})
+            self.map_metadata = self.map_metadata_collection.get_only()
             self.analysis_metadata_collection = \
                 self.subject_database.analysis_metadata
 

--- a/src/db_adapter.py
+++ b/src/db_adapter.py
@@ -75,6 +75,12 @@ class Collection:
             raise ValueError("find_one() requires a non-empty filter")
         return self._table.get(_build_query(query))
     
+    def get_only(self):
+        docs = self._table.all()
+        if len(docs) != 1:
+            raise ValueError(f"Expected exactly 1 document, found {len(docs)}")
+        return docs[0]
+    
     def insert_one(self, document):
         if not isinstance(document, dict):
             raise TypeError("insert_one() requires a dict document")


### PR DESCRIPTION
Old tinymongo code was happy to return first document hit on no-filter `find_one({})`. This behavior is guarded against in the new `db_adapter.py` layer, resulting in raising an error when loading map metadata in the GUI.

This PR adds a new `get_only` op to the db adapter, allowing simple retrieval of data in a singleton database collection. The GUI code is updated to use that instead of the no-filter `find_one`.

Resolves #38 