### PR TITLE
Refactoring SitePlot and the overall plotting pipeline

### DIFF
--- a/src/Field_Selection_GUI.py
+++ b/src/Field_Selection_GUI.py
@@ -1678,7 +1678,7 @@ class SitePlot(RelativeLayout):
         scaled = self._scale_sizes(self.val, self.max_bubble_size)
         self.bubble = ax.scatter(x=self.col, y=self.row, s=scaled ** 2,
                                  edgecolors="black", lw=0.5,
-                                 c=self.bubble_color)
+                                 color=self.bubble_color)
         ax.set_facecolor(axis_color)
         self._draw_tc_overlays(ax)
         ax.set_xlim([0, cfg.num_frequency])
@@ -1831,8 +1831,8 @@ class SitePlot(RelativeLayout):
         self.row, self.col = np.where(tc > 0)
         self.val = tc[self.row, self.col]
         scaled = self._scale_sizes(self.val, self.max_bubble_size)
-        self.bubble.update({"offsets": list(zip(self.col, self.row)),
-                            "sizes": scaled ** 2})
+        offsets = np.column_stack((self.col, self.row))
+        self.bubble.update({"offsets": offsets, "sizes": scaled ** 2})
 
     def update_bubble_size(self):
         """Rescale existing bubbles without refetching the TC."""

--- a/src/Field_Selection_GUI.py
+++ b/src/Field_Selection_GUI.py
@@ -1502,180 +1502,96 @@ class MapScroll(ScrollView):
 
 class SitePlot(RelativeLayout):
     """
-    Render PSTH and TC matplotlib plots inside Kivy.
-    Uses a flag to determine if obj is a MapScreen or SiteScreen (re: detailed)
-    plot item.
+    PSTH + TC rendering for one site.
+
+    Map instances share one SiteModel.
+    All analysis state and derived
+    arrays live on the model; this class is rendering and mouse
+    handling only.
     """
-    def __init__(self, **kwargs):
-        super(SitePlot, self).__init__(size_hint=kwargs["size_hint"],
-                                       pos_hint=kwargs["pos_hint"],
-                                       height=kwargs["height"], 
-                                       width=kwargs["width"])
+    def __init__(self, model, detailed_plot, is_ic,
+                 cf_cmap, heatmap_cmap, **layout_kwargs):
+        super().__init__(**layout_kwargs)
 
-        # Allow detailed site plot and overview-map plot to use different 
-        # settings by checking for a flag
-        self.detailed_plot = kwargs["detailed_plot"]
+        self.model = model
+        self.detailed_plot = detailed_plot
+        cfg = model.config
 
-        if self.detailed_plot:
+        if detailed_plot:
             # Listen for signals
             self.on_changes_signal = blinker.Signal()
             self.on_cf_pick_signal = blinker.Signal()
 
-        self.gui_instance = kwargs["gui_instance"]
-        self.site_number = kwargs["site_number"]
-        self.site_data = self.gui_instance.densetc_data[self.site_number]
-        self.site_analysis = self.gui_instance.densetc_analysis[self.site_number]
-
         # Allow user to change cmaps used for plots
-        self.cf_cmap = matplotlib.colormaps[kwargs["cf_cmap"]]
-        self.heatmap_cmap = kwargs["heatmap_cmap"]
+        self.cf_cmap = matplotlib.colormaps[cf_cmap]
+        self.heatmap_cmap = heatmap_cmap
         # TODO test 48khz
         self.norm = matplotlib.colors.Normalize(
-            vmin=0, vmax=self.gui_instance.num_frequency - 1)
+            vmin=0, vmax=cfg.num_frequency - 1)
 
+        # IC responses are faster than cortical, so the latency colour
+        # range is tighter and lower. PowerNorm(0.65) stretches the low
+        # end where most onsets sit.
+        lo, hi = (1, 16) if is_ic else (5, 20)
         self.speed_cmap = cmocean.cm.speed
-        if self.gui_instance.ic_bool:
-            # 1ms-16ms with greater dynamic range for IC maps
-            self.speed_norm = matplotlib.colors.PowerNorm(0.65, 
-                                                          vmin=1, 
-                                                          vmax=16)
-        else:
-            # 5ms-20ms with greater dynamic range
-            self.speed_norm = matplotlib.colors.PowerNorm(0.65, 
-                                                          vmin=5, 
-                                                          vmax=20)
+        self.speed_norm = matplotlib.colors.PowerNorm(0.65, vmin=lo, vmax=hi)
 
-        # User changes will be reflected in non-saved variables. A site can be 
-        # reset to the analysis default by copying the saved versions to the 
-        # non-saved variables. Any changes the user wants to save will be 
-        # copied into the saved variables, and then database will be updated.
-        self.cf_idx = self.site_analysis["cf_idx"]
-        self.saved_cf_idx = self.site_analysis["cf_idx"]
-        self.thresh_idx = self.site_analysis["threshold_idx"]
-        self.saved_thresh_idx = self.site_analysis["threshold_idx"]
-        self.onset = self.site_analysis["onset_ms"]
-        self.saved_onset = self.site_analysis["onset_ms"]
-        self.offset = self.site_analysis["offset_ms"]
-        self.saved_offset = self.site_analysis["offset_ms"]
-        self.peak = self.site_analysis["peak_ms"]
-        self.saved_peak = self.site_analysis["peak_ms"]
-        self.peak_driven_rate = self.site_analysis["peak_driven_rate_hz"]
-        self.saved_peak_driven_rate = self.site_analysis["peak_driven_rate_hz"]
-        self.spont_rate = self.site_analysis["spont_firing_rate_hz"]
-        self.bw_idx = {lvl: self.site_analysis[f"bw{lvl}_idx"].copy()
-                       for lvl in BW_LEVELS}
-        self.saved_bw_idx = {lvl: self.site_analysis[f"bw{lvl}_idx"].copy()
-                             for lvl in BW_LEVELS}
-        self.continuous_bw_idx = self.site_analysis["continuous_bw_idx"].copy()
-        self.saved_continuous_bw_idx = self.site_analysis["continuous_bw_idx"].copy()
-        try:
-            self.sdf = self.site_analysis["bb_sdf"].copy()
-        except KeyError:  # Analysis was made prior to versions adding sdf's
-            self.sdf = 0
-        try:
-            self.saved_marked = self.site_analysis["marked"]
-            self.marked = self.saved_marked
-        except KeyError:  # Analysis was made prior to adding marks
-            self.saved_marked = False
-            self.marked = False
-
-        # Initialize possible plot options
+        # Display toggles
+        self.use_smooth_tc = False
+        self.use_lineplot = False
+        self.use_heatmap = False
+        self.use_contour = False
+        self.use_bw = True
         self.manually_hidden = False
+        if detailed_plot:
+            self.active = False
+            self.bin_size = 1
+            self.max_bubble_size = 30
+        else:
+            self.active = True
+            self.bin_size = 5
+            self.max_bubble_size = 6
+
+        # Artist handles, populated on render
         self.bubble = None
         self.line = None
         self.heatmap = None
         self.psth = None
-        self.fire_txt = None
-        self.cf_txt = None
         self.latency_txt = None
-        self.use_smooth_tc = False
-        self.smooth_tuning_curve = None
-        self.filtered_tuning_curve = None
-        self.tuning_curve_contour = None
-        self.use_lineplot = False
-        self.use_heatmap = False
         self.cf_marker = None
-        self.bw_lines = {lvl: None for lvl in BW_LEVELS}
-        self.bw_markers = {lvl: [None, None] for lvl in BW_LEVELS}
-        self.bw_press = {lvl: [False, False] for lvl in BW_LEVELS}
         self.contour_line = None
-        self.picking_cf = False
-        self.picking_bw = False
-        self.bw_pressed = False
-        self.use_bw = True
-        if self.detailed_plot:
-            self.active = False
-            self.use_contour = False #True
-            self.bin_size = 1
-        else:
-            self.active = True
-            self.use_contour = False
-            self.bin_size = 5
-
         self.sdf_line = None
-
-        # Initialize latency/spont line properties
+        self.spont_line = None
         self.onset_line = None
         self.offset_line = None
-        self.spont_line = None
+        self.bw_lines = {lvl: None for lvl in cfg.bw_levels_db}
+        self.bw_markers = {lvl: [None, None] for lvl in cfg.bw_levels_db}
 
-        # Initialize latency interaction flags (switched to 1 when user clicks 
-        # on a latency line)
-        self.onset_press = 0
-        self.offset_press = 0
+        # Interaction flags
+        self.onset_press = False
+        self.offset_press = False
+        self.picking_cf = False
+        self.bw_pressed = False
+        self.bw_press = {lvl: [False, False] for lvl in cfg.bw_levels_db}
 
-        # All bubbles in a plot will be drawn in relation to this maximum. 
-        # Change if wanted.
-        self.max_bubble_size = 6
-
-        # Get TC for this site
-        site_df = pd.DataFrame(self.site_data["spiketrains"])
-        self.tuning_curve_df = afunc.get_tuning_curve_dataframe(site_df)
-        self.raw_tuning_curve = np.array(self.tuning_curve_df.map(
-                lambda x: 
-                    afunc.remove_spont(x, 
-                                       driven_onset_ms=self.onset, 
-                                       driven_offset_ms=self.offset,
-                                       spont_onset_ms=400 - (self.offset - 
-                                                             self.onset),
-                                       spont_offset_ms=400)
-                    if ((x is not None) and (not np.any(np.isnan(x)))) 
-                    else 0)).astype(np.uint8)
-
-        self.ttest_spike_counts = afunc.get_driven_vs_spont_spike_counts(
-            self.tuning_curve_df, 
-            driven_onset_ms=self.onset, 
-            driven_offset_ms=self.offset,
-            spont_onset_ms=400 - (self.offset - self.onset),
-            spont_offset_ms=400)
-        self.ttest_tc = afunc.ttest_driven_vs_spont_tc(*self.ttest_spike_counts)
-        self.saved_contour_tc = afunc.ttest_analyze_tuning_curve(self.ttest_tc)[0]
-        # Threshold so only 1 contour level is drawn
-        self.saved_contour_tc[0 < self.saved_contour_tc] = 1
-        self.contour_tc = self.saved_contour_tc.copy()
-
-        # Get values and indices from tuning curve array for bubble / line plot
-        self.row, self.col = np.where(0 < self.raw_tuning_curve)
-        self.val = self.raw_tuning_curve[self.row, self.col]
+        # Last-rendered TC values, kept so update_bubble_size() can
+        # rescale without refetching the array.
+        self.row = self.col = self.val = np.array([])
 
         # Generate bubble plot and psth
         self.fig, self.ax = plt.subplots(2, 1)
-        self.ax[0].axis("off")
-        self.ax[1].axis("off")
-        self.raw_psth = np.array(self.site_analysis["psth"])
-        if self.cf_idx is None:
-            self.bubble_color = "r"
-            self.lat_color = "m"
-        else:
-            self.bubble_color = self.cf_cmap(self.norm(self.cf_idx))
-            self.lat_color = self.speed_cmap(self.speed_norm(self.onset))
-
-        self.bubble_plot()
-        self.psth_plot()
 
         # Aesthetics
         self.fig.patch.set_alpha(0)
         self.fig.subplots_adjust(wspace=0, hspace=0)
+        
+        if not detailed_plot:
+            self.bubble_plot()
+            self.psth_plot()
+        else:
+            self.ax[0].axis("off")
+            self.ax[1].axis("off")
+
         # Generate Kivy widget for displaying in GUI
         self.figure_canvas = FigureCanvas(self.fig)
 
@@ -1689,36 +1605,277 @@ class SitePlot(RelativeLayout):
 
         self.add_widget(self.figure_canvas)
 
-    def mouse_click_event(self, event):
-        """User interaction with latency or bandwidth lines."""
-        event.x, event.y = self.to_window(*self.to_parent(event.x, event.y))
-        if self.detailed_plot:
-            if self.active:
-                """
-                Checking event.inaxes is unpredictable when x, y need 
-                transformation (as they do here), since event.inaxes is created
-                before the transformation is done (and will return None in some
-                cases at the edge of axes. No good!). Instead, transform x, y 
-                into axes to check if point falls inside bounding box (values 
-                between 0-1 fall inside axes, other values are outside).
-                """
-                x_coor_ax0, y_coor_ax0 = \
-                    self.ax[0].transAxes.inverted().transform([event.x, 
-                                                               event.y])
-                x_coor_ax1, y_coor_ax1 = \
-                    self.ax[1].transAxes.inverted().transform([event.x, 
-                                                               event.y])
-                if (0 <= x_coor_ax0 <= 1) and (0 <= y_coor_ax0 <= 1):
-                    self.on_pick_line(event)
-                elif (0 <= x_coor_ax1 <= 1) and (0 <= y_coor_ax1 <= 1):
-                    if self.picking_cf:
-                        self.pick_cf(event)
-                    elif self.use_bw:
-                        # Only allow pick_bw() if bw's are visible
-                        self.pick_bw(event)
+    # -- shortcuts ------------------------------------------------------
+    @property
+    def st(self):
+        """Working analysis state (model.working). All edits go here."""
+        return self.model.working
+
+    @property
+    def bubble_color(self):
+        cf = self.st.cf_idx
+        return "r" if cf is None else self.cf_cmap(self.norm(cf))
+
+    @property
+    def lat_color(self):
+        # Non-responsive sites (no CF) get a sentinel colors for TC and PSTH.
+        if self.st.cf_idx is None:
+            return "m"
+        return self.speed_cmap(self.speed_norm(self.st.onset))
+    
+    def _current_tc(self):
+        """
+        TC array for the active rendering, respecting use_smooth_tc.
+        Memoised on (onset, offset) inside the model, so calling this on
+        every redraw is free unless latencies moved.
+        """
+        if self.use_smooth_tc:
+            return self.model.ttest_tc()
+        return self.model.raw_tc()
+
+    @staticmethod
+    def _scale_sizes(vals, max_size):
+        """
+        Scale to [0, max_size], appending a 0 so the full range is used
+        (otherwise the lowest spike count maps to size 0). Returns the
+        input unchanged if it's empty.
+        """
+        try:
+            return minmax_scale(list(vals) + [0],
+                                feature_range=(0, max_size))[:-1]
+        except TypeError:
+            return vals
+    
+    # -- full renders ---------------------------------------------------
+    def re_plot(self, axis_visible="off", min_y=None):
+        """Re-plot TC."""
+        if self.use_lineplot:
+            self.line_plot(axis_visible=axis_visible)
+        elif self.use_heatmap:
+            self.heatmap_plot(axis_visible=axis_visible)
         else:
-            # Map-wide axes coords don't line up with event coords even after
-            # this transformation
+            self.bubble_plot(axis_visible=axis_visible)
+        self.psth_plot(min_y=min_y)
+
+    def re_color(self, cf_cmap="viridis", heatmap_cmap="inferno"):
+        """Update bubble plot or heatmap colors."""
+        self.heatmap_cmap = heatmap_cmap
+        self.cf_cmap = matplotlib.colormaps[cf_cmap]
+        # TODO allow user to change No CF color (default is red)
+        if self.use_heatmap and self.heatmap is not None:
+            self.heatmap.set_cmap(self.heatmap_cmap)
+        elif not self.use_lineplot and self.bubble is not None:
+            self.bubble.update({"facecolors": self.bubble_color})
+
+    def bubble_plot(self, axis_visible="off", axis_color="xkcd:white"):
+        ax = self.ax[1]
+        cfg = self.model.config
+        tc = self._current_tc()
+        self.row, self.col = np.where(tc > 0)
+        self.val = tc[self.row, self.col]
+
+        ax.clear()
+        scaled = self._scale_sizes(self.val, self.max_bubble_size)
+        self.bubble = ax.scatter(x=self.col, y=self.row, s=scaled ** 2,
+                                 edgecolors="black", lw=0.5,
+                                 c=self.bubble_color)
+        ax.set_facecolor(axis_color)
+        self._draw_tc_overlays(ax)
+        ax.set_xlim([0, cfg.num_frequency])
+        ax.set_ylim([0, cfg.num_intensity])
+        ax.axis(axis_visible)
+
+    def line_plot(self, axis_visible="on", axis_color="xkcd:black"):
+        """Matches older analysis plotting style (tc_exploror, iykyk)."""
+        ax = self.ax[1]
+        cfg = self.model.config
+        max_len = 1
+        tc = self._current_tc()
+        self.row, self.col = np.where(tc > 0)
+        self.val = tc[self.row, self.col]
+
+        ax.clear()
+        scaled = self._scale_sizes(self.val, max_len)
+        segs = [[[x, y + 0.25], [x, y + 0.25 - s]]
+                for x, y, s in zip(self.col, self.row, scaled)]
+        self.line = LineCollection(segs, linewidths=2, colors="y")
+        ax.add_collection(self.line)
+        ax.set_facecolor(axis_color)
+        self._draw_tc_overlays(
+            ax, contour_color="xkcd:white" if self.detailed_plot else None)
+        ax.set_xlim([0, cfg.num_frequency])
+        ax.set_ylim([0, cfg.num_intensity])
+        ax.axis(axis_visible)
+
+    def heatmap_plot(self, axis_visible="on"):
+        """For fun and profit (and heat)."""
+        ax = self.ax[1]
+        cfg = self.model.config
+        tc = self._current_tc()
+
+        ax.clear()
+        self.heatmap = ax.imshow(tc, cmap=self.heatmap_cmap, aspect="auto")
+        self._draw_tc_overlays(
+            ax, contour_color="xkcd:white" if self.detailed_plot else None)
+        ax.set_xlim([0, cfg.num_frequency - 1])
+        ax.set_ylim([0, cfg.num_intensity - 1])
+        ax.axis(axis_visible)
+
+    def _draw_tc_overlays(self, ax, contour_color=None):
+        """
+        DCF marker, BW lines/markers, and contour on top of whichever TC
+        rendering just populated `ax`. Dark-background renderings pass
+        a white contour_color; None uses matplotlib's default cycle.
+        """
+        cfg = self.model.config
+        st = self.st
+
+        if self.use_bw and st.cf_idx is not None:
+            for lvl in cfg.bw_levels_db:
+                idx = st.bw_idx[lvl]
+                if idx[0] is None:
+                    continue
+                y = st.thresh_idx + cfg.bw_row_offset(lvl)
+                self.bw_lines[lvl] = ax.plot(idx, [y, y], "r", lw=1.5)[0]
+                if self.detailed_plot:
+                    self.bw_markers[lvl][0] = ax.plot(
+                        idx[0], y, "rd", ms=8, picker=5)[0]
+                    self.bw_markers[lvl][1] = ax.plot(
+                        idx[1], y, "rd", ms=8, picker=5)[0]
+
+        if self.use_contour:
+            contour = self.model.contour_tc()
+            if contour_color:
+                self.contour_line = ax.contour(contour, levels=[0],
+                                               colors=contour_color)
+            else:
+                self.contour_line = ax.contour(contour, levels=[0])
+
+        if st.cf_idx is not None:
+            self.cf_marker = ax.plot(st.cf_idx, st.thresh_idx,
+                                     "r*", ms=8, alpha=0.5)[0]
+
+    def psth_plot(self, min_y=None):
+        ax = self.ax[0]
+        cfg = self.model.config
+        st = self.st
+        raw = self.model.raw_psth
+        sweep = cfg.sweep_length_ms
+        bin_size = self.bin_size
+
+        ax.clear()
+        if bin_size in (1, 5):
+            num_bins = round((sweep - 1) / bin_size)
+            binned = np.histogram(range(len(raw)), bins=num_bins,
+                                  weights=raw)[0]
+        else:
+            binned = raw
+            num_bins = len(binned)
+
+        hist_peak = int(np.argmax(binned))
+        # Quick visual peak rate (not the driven rate), and it changes
+        # with bin size. Just a label, not an analysis output.
+        # TODO Clarity and explicitness on the user end is a good thing to aim for
+        ms_mult = 1000 // bin_size
+        peak_rate = int(round((binned[hist_peak] * ms_mult) / cfg.num_tones))
+
+        self.psth = ax.hist(range(len(raw)), weights=raw, bins=num_bins,
+                            alpha=1, color=self.lat_color,
+                            edgecolor="#fdfdfe", lw=0.4,
+                            histtype="stepfilled")
+
+        if self.detailed_plot:
+            self.sdf_line = ax.plot(
+                self.model.sdf * bin_size * cfg.num_tones,
+                lw=2, color="xkcd:amber")[0]
+
+        # If a minimum max y-lim value is set (so small Hz do indeed look 
+        # small), set it IF it is larger than current
+        if min_y:
+            min_y_counts = (min_y / ms_mult) * cfg.num_tones
+            if ax.get_ylim()[1] < min_y_counts:
+                ax.set_ylim([0, min_y_counts])
+                y_val = min_y_counts
+            else:
+                y_val = binned[hist_peak]
+        else:
+            y_val = binned[hist_peak]
+
+        cf_val = ("-" if st.cf_idx is None
+                  else f"{cfg.frequencies_hz[st.cf_idx] / 1000:.1f}")
+        self.latency_txt = ax.annotate(
+            f"On: {st.onset}, Pk: {st.peak}, Off: {st.offset}\n"
+            f"Rate: {peak_rate} Hz, CF: {cf_val} kHz",
+            (1.25, 0), xytext=[st.offset + 5, y_val],
+            size=10, va="top", name="Segoe UI", weight="bold",
+            color="xkcd:dark blue")
+        ax.set_xlim([0, sweep - 1])
+
+        # If detailed plot, plot spontaneous and SDF
+        if self.detailed_plot:
+            # Spont was calculated at 1ms bin size
+            spont = (self.model.spont_rate / 1000) * bin_size * cfg.num_tones
+            self.spont_line = ax.plot([0,sweep-1], [spont,spont], "c", lw=2)[0]
+
+        # Plot latency lines on psth
+        lat_lw = 3 if self.detailed_plot else 1
+        self.onset_line = ax.plot([st.onset, st.onset], [0, y_val],
+                                  "r", lw=lat_lw, picker=2)[0]
+        self.offset_line = ax.plot([st.offset, st.offset], [0, y_val],
+                                   "r", lw=lat_lw, picker=2)[0]
+        ax.axis("off")
+
+    # -- partial updates during latency drag ----------------------------
+    def update_bubble(self):
+        tc = self._current_tc()
+        self.row, self.col = np.where(tc > 0)
+        self.val = tc[self.row, self.col]
+        scaled = self._scale_sizes(self.val, self.max_bubble_size)
+        self.bubble.update({"offsets": list(zip(self.col, self.row)),
+                            "sizes": scaled ** 2})
+
+    def update_bubble_size(self):
+        """Rescale existing bubbles without refetching the TC."""
+        scaled = self._scale_sizes(self.val, self.max_bubble_size)
+        self.bubble.update({"sizes": scaled ** 2})
+
+    def update_line(self):
+        max_len = 1
+        tc = self._current_tc()
+        self.row, self.col = np.where(tc > 0)
+        self.val = tc[self.row, self.col]
+        scaled = self._scale_sizes(self.val, max_len)
+        segs = [[[x, y + 0.25], [x, y + 0.25 - s]]
+                for x, y, s in zip(self.col, self.row, scaled)]
+        self.line.set_segments(segs)
+
+    def update_heatmap(self):
+        self.heatmap.set_data(self._current_tc())
+
+    # -- mouse handling -------------------------------------------------
+    def mouse_click_event(self, event):
+        event.x, event.y = self.to_window(*self.to_parent(event.x, event.y))
+        if not self.active:
+            return
+        if self.detailed_plot:
+            # event.inaxes is unreliable after the coord transform above
+            # (it's computed pre-transform and can be None near axis
+            # edges). Transform into each axes' unit coords instead.
+            x0, y0 = self.ax[0].transAxes.inverted().transform(
+                [event.x, event.y])
+            x1, y1 = self.ax[1].transAxes.inverted().transform(
+                [event.x, event.y])
+            if 0 <= x0 <= 1 and 0 <= y0 <= 1:
+                self.on_pick_line(event)
+            elif 0 <= x1 <= 1 and 0 <= y1 <= 1:
+                if self.picking_cf:
+                    self.pick_cf(event)
+                elif self.use_bw:
+                    self.pick_bw(event)
+        else:
+            # Overview axes coords don't line up with event coords even
+            # after the transform, so let on_pick_line do its own
+            # contains() check.
             self.on_pick_line(event)
 
     def mouse_move_event(self, event):
@@ -1737,595 +1894,106 @@ class SitePlot(RelativeLayout):
         elif self.active and self.bw_pressed:
             self.off_bw()
 
-    def re_color(self, cf_cmap="viridis", heatmap_cmap="inferno"):
-        """Update bubble plot or heatmap colors."""
-        self.heatmap_cmap = heatmap_cmap
-        self.cf_cmap = matplotlib.colormaps[cf_cmap]
-        if self.cf_idx is not None:
-            # TODO allow user to change No CF color (default is red)
-            self.bubble_color = self.cf_cmap(self.norm(self.cf_idx))
-        if self.use_heatmap:
-            self.heatmap.set_cmap(self.heatmap_cmap)
-        elif not self.use_lineplot:
-            self.bubble.update({"facecolors": self.bubble_color})
-
-    def re_plot(self, axis_visible="off", min_y=None):
-        """Re-plot TC."""
-        if self.use_lineplot:
-            self.line_plot(axis_visible=axis_visible)
-        elif self.use_heatmap:
-            self.heatmap_plot(axis_visible=axis_visible)
-        else:
-            self.bubble_plot(axis_visible=axis_visible)
-        self.psth_plot(min_y=min_y)
-
     def on_pick_line(self, event):
-        """Initial UX for user updating latency line."""
-        if self.active:
-            if self.detailed_plot:
-                lat_lw = 5
-            else:
-                lat_lw = 1.5
-            if self.onset_line.contains(event)[0]:
-                self.onset_line.set_lw(lat_lw)
-                self.onset_press = 1
-                event.canvas.draw()
-
-            elif self.offset_line.contains(event)[0]:
-                self.offset_line.set_lw(lat_lw)
-                self.offset_press = 1
-                event.canvas.draw()
+        lat_lw = 5 if self.detailed_plot else 1.5
+        if self.onset_line.contains(event)[0]:
+            self.onset_line.set_lw(lat_lw)
+            self.onset_press = True
+            event.canvas.draw()
+        elif self.offset_line.contains(event)[0]:
+            self.offset_line.set_lw(lat_lw)
+            self.offset_press = True
+            event.canvas.draw()
 
     def move_line(self, x, y):
-        """Ongoing UX for user updating latency line."""
-        # trans_x/y are in display coordinates (see MPL doc for info for
-        # definition)
-        # Must transform into axes user data coordinates (xlim, ylim) in order
-        # to move line to appropriate x-coordinate based on mouse position
-        ax_inv = self.ax[0].transData.inverted()
-        xdata, ydata = ax_inv.transform((x, y))
+        xdata, _ = self.ax[0].transData.inverted().transform((x, y))
         if xdata is None:
             return
+        cfg = self.model.config
+        st = self.st
 
-        # TODO generalize sweep length
-        if self.onset_press and (0 <= xdata <= 400):
-            if xdata < self.offset_line.get_xdata()[0]:
-                self.onset_line.set_xdata([xdata, xdata])
-                self.onset = int(round(xdata))
-                if self.detailed_plot:
-                    self.on_changes_signal.send()
-                    peak_hist = self.raw_psth.copy()
-                    peak_hist[0:self.onset] = peak_hist[self.offset:] = 0
-                    self.peak = int(np.argmax(peak_hist))
-
-                    self.peak_driven_rate = \
-                        afunc.get_peak_driven_rate(
-                            self.raw_psth[self.onset:self.offset],
-                            self.spont_rate,
-                            self.gui_instance.num_tones)
-                    self.latency_txt.set_text(
-                        f"{self.onset}, {self.peak}, {self.offset}")
-
-                if self.use_lineplot:
-                    self.update_line()
-                elif self.use_heatmap:
-                    self.update_heatmap()
-                else:
-                    self.update_bubble()
-                self.figure_canvas.draw()
-
-        # TODO generalize sweep length
-        elif self.offset_press and (0 <= xdata <= 400):
-            if xdata > self.onset_line.get_xdata()[0]:
-                self.offset_line.set_xdata([xdata, xdata])
-                self.offset = int(round(xdata))
-                if self.detailed_plot:
-                    self.on_changes_signal.send()
-                    peak_hist = self.raw_psth.copy()
-                    peak_hist[0:self.onset] = peak_hist[self.offset:] = 0
-                    self.peak = int(np.argmax(peak_hist))
-
-                    self.peak_driven_rate = \
-                        afunc.get_peak_driven_rate(
-                            self.raw_psth[self.onset:self.offset],
-                            self.spont_rate,
-                            self.gui_instance.num_tones)
-                    self.latency_txt.set_text(
-                        f"{self.onset}, {self.peak}, {self.offset}")
-                    
-                if self.use_lineplot:
-                    self.update_line()
-                elif self.use_heatmap:
-                    self.update_heatmap()
-                else:
-                    self.update_bubble()
-                self.figure_canvas.draw()
-
-    def update_heatmap(self):
-        """Update heatmap without fully re-plotting."""
-        if self.use_smooth_tc:
-            ttest_spike_counts = afunc.get_driven_vs_spont_spike_counts(
-                self.tuning_curve_df, 
-                driven_onset_ms=self.onset, 
-                driven_offset_ms=self.offset,
-                spont_onset_ms=400 - (self.offset - self.onset),
-                spont_offset_ms=400)
-            tc_image = afunc.ttest_driven_vs_spont_tc(*ttest_spike_counts)
+        # Onset/offset drags are identical apart from which line/field
+        # they touch and the no-crossover constraint.
+        if self.onset_press and 0 <= xdata <= cfg.sweep_length_ms \
+                and xdata < self.offset_line.get_xdata()[0]:
+            self.onset_line.set_xdata([xdata, xdata])
+            st.onset = int(round(xdata))
+        elif self.offset_press and 0 <= xdata <= cfg.sweep_length_ms \
+                and xdata > self.onset_line.get_xdata()[0]:
+            self.offset_line.set_xdata([xdata, xdata])
+            st.offset = int(round(xdata))
         else:
-            self.raw_tuning_curve = np.array(self.tuning_curve_df.map(
-                lambda x: 
-                    afunc.remove_spont(x, 
-                                       driven_onset_ms=self.onset, 
-                                       driven_offset_ms=self.offset,
-                                       spont_onset_ms=400 - (self.offset - 
-                                                             self.onset),
-                                       spont_offset_ms=400)
-                    if ((x is not None) and (not np.any(np.isnan(x))))
-                    else 0)).astype(np.uint8)
-            tc_image = self.raw_tuning_curve
-
-        self.heatmap.set_data(tc_image)
-
-    def update_line(self):
-        """Update lineplot without fully re-plotting."""
-        max_line_length = 1
-        self.raw_tuning_curve = np.array(self.tuning_curve_df.map(
-            lambda x: 
-                afunc.remove_spont(x, 
-                                   driven_onset_ms=self.onset, 
-                                   driven_offset_ms=self.offset,
-                                   spont_onset_ms=400 - (self.offset - 
-                                                         self.onset),
-                                   spont_offset_ms=400) 
-                if x is not None else 0)).astype(np.uint8)
-        if self.use_smooth_tc:
-            self.filtered_tuning_curve = afunc.analyze_tuning_curve(
-                self.raw_tuning_curve)[1]
-            self.row, self.col = np.where(self.filtered_tuning_curve > 0)
-            self.val = self.filtered_tuning_curve[self.row, self.col]
-        else:
-            self.row, self.col = np.where(self.raw_tuning_curve > 0)
-            self.val = self.raw_tuning_curve[self.row, self.col]
-
-        x = self.col
-        y = self.row
-        s = self.val
-
-        try:
-            scaled_s = minmax_scale(list(s) + [0], 
-                                    feature_range=(0, max_line_length))[:-1]
-        except TypeError:
-            # Thrown if s contains no values (non-responsive site)
-            scaled_s = s
-
-        line_list = [[[x_, y_ + 0.25], [x_, y_ + 0.25 - s_]] for 
-                     x_, y_, s_ in zip(x, y, scaled_s)]
-        self.line.set_segments(line_list)
-
-    def update_bubble(self):
-        """Update bubble plot without fully re-plotting."""
-        if self.use_smooth_tc:
-            ttest_spike_counts = afunc.get_driven_vs_spont_spike_counts(
-                self.tuning_curve_df, 
-                driven_onset_ms=self.onset, 
-                driven_offset_ms=self.offset,
-                spont_onset_ms=400 - (self.offset - self.onset),
-                spont_offset_ms=400)
-            self.filtered_tuning_curve = \
-                afunc.ttest_driven_vs_spont_tc(*ttest_spike_counts)
-            self.row, self.col = np.where(0 < self.filtered_tuning_curve)
-            self.val = self.filtered_tuning_curve[self.row, self.col]
-        else:
-            self.raw_tuning_curve = np.array(self.tuning_curve_df.map(
-                lambda x: 
-                    afunc.remove_spont(x, 
-                                       driven_onset_ms=self.onset, 
-                                       driven_offset_ms=self.offset,
-                                       spont_onset_ms=400 - (self.offset - 
-                                                             self.onset),
-                                       spont_offset_ms=400)
-                    if ((x is not None) and (not np.any(np.isnan(x))))
-                    else 0)).astype(np.uint8)
-            self.row, self.col = np.where(self.raw_tuning_curve > 0)
-            self.val = self.raw_tuning_curve[self.row, self.col]
-
-        x = self.col
-        y = self.row
-        s = self.val
-
-        """
-        Scale bubble size against a maximum value. Add [0] to ensure entire 
-        dynamic range is used (otherwise lowest spike value will default to 
-        lowest bubble size -- here, 0).
-        """
-        try:
-            scaled_s = minmax_scale(
-                list(s) + [0], feature_range=(0, self.max_bubble_size))[:-1]
-        except TypeError:
-            # Thrown if s contains no values (non-responsive site)
-            scaled_s = s
-
-        offsets = np.column_stack((x, y))
-        self.bubble.update({"offsets": offsets, "sizes": scaled_s ** 2})
-
-    def update_bubble_size(self):
-        """
-        Quick function to only update the size of the bubbles. Call 
-        update_bubble() instead if positions or values need updating.
-        """
-        s = self.val
-
-        """
-        Scale bubble size against a maximum value. Add [0] to ensure entire 
-        dynamic range is used (otherwise lowest spike value will default to 
-        lowest bubble size -- here, 0).
-        """
-        try:
-            scaled_s = minmax_scale(
-                list(s) + [0], feature_range=(0, self.max_bubble_size))[:-1]
-        except TypeError:
-            # Thrown if s contains no values (non-responsive site)
-            scaled_s = s
-
-        self.bubble.update({"sizes": scaled_s ** 2})
-
-    def _draw_tc_overlays(self, ax, contour_color=None):
-        """
-        Draw CF marker, BW lines/markers, and contour on top of whichever
-        TC rendering (bubble / line / heatmap) just populated `ax`.
-
-        `contour_color` lets the dark-background plots (line, heatmap in
-        detailed view) force a white contour; None uses matplotlib's cycle.
-        """
-        if self.use_bw and (self.cf_idx is not None):
-            for lvl in BW_LEVELS:
-                idx = self.bw_idx[lvl]
-                if idx[0] is None:
-                    continue
-                y = self.thresh_idx + lvl // 5  # assumes 5 dB steps — TODO issue #13
-                self.bw_lines[lvl] = ax.plot(idx, [y, y], "r", lw=1.5)[0]
-                if self.detailed_plot:
-                    self.bw_markers[lvl][0] = ax.plot(
-                        idx[0], y, "rd", ms=8, picker=5)[0]
-                    self.bw_markers[lvl][1] = ax.plot(
-                        idx[1], y, "rd", ms=8, picker=5)[0]
-
-        if self.use_contour:
-            if contour_color:
-                self.contour_line = ax.contour(self.contour_tc, levels=[0],
-                                               colors=contour_color)
-            else:
-                self.contour_line = ax.contour(self.contour_tc, levels=[0])
-
-        if self.cf_idx is not None:
-            self.cf_marker = ax.plot(self.cf_idx, self.thresh_idx,
-                                     "r*", ms=8, alpha=0.5)[0]
-
-    def bubble_plot(self, ax=None, x=None, y=None, s=None, color=None, 
-                    axis_visible="off", axis_color="xkcd:white"):
-        """
-        Done for SiteScreen.__init__(). It updates bubble size and axis, but 
-        doesn't (currently) have this data so it was easier at the time of 
-        writing to just make the defaults available and simply call 
-        .bubble_plot() to get modified version of an existing plot.
-        """
-        if ax is None:
-            ax = self.ax[1]
-        if None in [x, y, s]:
-            # User must pass all 3 kwargs if they want to plot something 
-            # different than default plot behavior
-
-            if self.use_smooth_tc:
-                ttest_spike_counts = afunc.get_driven_vs_spont_spike_counts(
-                    self.tuning_curve_df, 
-                    driven_onset_ms=self.onset, 
-                    driven_offset_ms=self.offset,
-                    spont_onset_ms=400 - (self.offset - self.onset),
-                    spont_offset_ms=400)
-                self.filtered_tuning_curve = \
-                    afunc.ttest_driven_vs_spont_tc(*ttest_spike_counts)
-                self.row, self.col = np.where(0 < self.filtered_tuning_curve)
-                self.val = self.filtered_tuning_curve[self.row, self.col]
-            else:
-                self.raw_tuning_curve = np.array(self.tuning_curve_df.map(
-                    lambda x: 
-                        afunc.remove_spont(x, 
-                                           driven_onset_ms=self.onset,
-                                           driven_offset_ms=self.offset,
-                                           spont_onset_ms=400 - (self.offset -
-                                                                 self.onset),
-                                           spont_offset_ms=400)
-                       if ((x is not None) and (not np.any(np.isnan(x))))
-                       else 0)).astype(np.uint8)
-                self.row, self.col = np.where(0 < self.raw_tuning_curve)
-                self.val = self.raw_tuning_curve[self.row, self.col]
-
-            x = self.col
-            y = self.row
-            s = self.val
-
-        if color is None:
-            color = self.bubble_color
-
-        ax.clear()
-        """
-        Scale bubble size against a maximum value. Add [0] to ensure entire 
-        dynamic range is used (otherwise lowest spike value will default to 
-        lowest bubble size -- here, 0).
-        """
-        try:
-            scaled_s = minmax_scale(
-                list(s) + [0], feature_range=(0, self.max_bubble_size))[:-1]
-        except TypeError:
-            # Thrown if s contains no values (non-responsive site)
-            scaled_s = s
-        self.bubble = ax.scatter(x=x, y=y, s=scaled_s ** 2, edgecolors="black",
-                                 lw=0.5, color=color)
-        ax.set_facecolor(axis_color)
-
-        self._draw_tc_overlays(ax)
-
-        ax.set_xlim([0, self.gui_instance.num_frequency])
-        ax.set_ylim([0, self.gui_instance.num_intensity])
-        ax.axis(axis_visible)
-
-    def line_plot(self, ax=None, x=None, y=None, s=None, axis_visible="on", 
-                  axis_color="xkcd:black"):
-        """
-        Old tc_explore style line plot.
-        """
-        max_line_length = 1
-        if ax is None:
-            ax = self.ax[1]
-        if None in [x, y, s]:
-            # User must pass all 3 kwargs if they want to plot something 
-            # different than default plot behavior
-            self.raw_tuning_curve = np.array(self.tuning_curve_df.map(
-                lambda x: 
-                    afunc.remove_spont(x, 
-                                       driven_onset_ms=self.onset, 
-                                       driven_offset_ms=self.offset,
-                                       spont_onset_ms=400 - (self.offset - 
-                                                             self.onset),
-                                       spont_offset_ms=400)
-                    if ((x is not None) and (not np.any(np.isnan(x))))
-                    else 0)).astype(np.uint8)
-            if self.use_smooth_tc:
-                self.filtered_tuning_curve = afunc.analyze_tuning_curve(
-                    self.raw_tuning_curve)[1]
-                self.row, self.col = np.where(self.filtered_tuning_curve > 0)
-                self.val = self.filtered_tuning_curve[self.row, self.col]
-            else:
-                self.row, self.col = np.where(self.raw_tuning_curve > 0)
-                self.val = self.raw_tuning_curve[self.row, self.col]
-
-            x = self.col
-            y = self.row
-            s = self.val
-
-        ax.clear()
-        try:
-            scaled_s = minmax_scale(list(s) + [0], 
-                                    feature_range=(0, max_line_length))[:-1]
-        except TypeError:
-            # Thrown if s contains no values (non-responsive site)
-            scaled_s = s
-
-        line_list = [[[x_, y_+0.25], [x_, y_+0.25 - s_]] for 
-                     x_, y_, s_ in zip(x, y, scaled_s)]
-        self.line = LineCollection(line_list, linewidths=2, colors="y")
-        ax.add_collection(self.line)
-        ax.set_facecolor(axis_color)
-
-        self._draw_tc_overlays(
-            ax, contour_color="xkcd:white" if self.detailed_plot else None)
-        
-        ax.set_xlim([0, self.gui_instance.num_frequency])
-        ax.set_ylim([0, self.gui_instance.num_intensity])
-        ax.axis(axis_visible)
-
-    def heatmap_plot(self, ax=None, tc_image=None, axis_visible="on"):
-        """
-        I like heatmaps and bubbles.
-        """
-        if ax is None:
-            ax = self.ax[1]
-        if tc_image is None:
-            # User must pass all 3 kwargs if they want to plot something 
-            # different than default plot behavior
-            self.raw_tuning_curve = np.array(self.tuning_curve_df.map(
-                lambda x: 
-                    afunc.remove_spont(x, 
-                                       driven_onset_ms=self.onset, 
-                                       driven_offset_ms=self.offset,
-                                       spont_onset_ms=400 - (self.offset - 
-                                                             self.onset),
-                                       spont_offset_ms=400)
-                    if ((x is not None) and (not np.any(np.isnan(x))))
-                    else 0)).astype(np.uint8)
-            if self.use_smooth_tc:
-                tc_image = afunc.analyze_tuning_curve(self.raw_tuning_curve)[1]
-            else:
-                tc_image = self.raw_tuning_curve
-
-        ax.clear()
-        self.heatmap = ax.imshow(tc_image, cmap=self.heatmap_cmap, 
-                                 aspect="auto")
-
-        self._draw_tc_overlays(
-            ax, contour_color="xkcd:white" if self.detailed_plot else None)
-        
-        ax.set_xlim([0, self.gui_instance.num_frequency-1])
-        ax.set_ylim([0, self.gui_instance.num_intensity-1])
-        ax.axis(axis_visible)
-
-    def psth_plot(self, ax=None, axis_visible="off", bin_size=None, 
-                  sweep_length=399, min_y=None):
-        """
-        Plots PSTH (originally done in __init__; breaking it out allows updates 
-        to bin size, colors, markers, spont line etc.
-        """
-        if ax is None:
-            ax = self.ax[0]
-        if bin_size is None:
-            bin_size = self.bin_size
-
-        ax.clear()
-        if bin_size in [1, 5]:  # Currently only 1 and 5ms are supported.
-            # Assumes 400ms tone sweep. Pass value for speech, or other.
-            num_bins = round(sweep_length / bin_size)
-            psth_binned = np.histogram(range(len(self.raw_psth)), 
-                                       bins=num_bins, weights=self.raw_psth)[0]
-        else:
-            # raw_psth should already be 1ms binned.
-            psth_binned = self.raw_psth
-            num_bins = len(psth_binned)
-
-        hist_peak = np.argmax(psth_binned)
-        """
-        Get peak spike rate. This is not the same as driven rate. It also 
-        changes depending on bin-size selection. This is just to be used as a 
-        quick visual tool for inspecting site without needing psth y-axis 
-        clutter.
-        """
-        if bin_size == 5:
-            ms_multiplier = 200  # Get rate in Hz; 5ms * 200 = 1s
-        else:
-            ms_multiplier = 1000  # 1ms * 1000
-        peak_spike_rate = int(round((psth_binned[hist_peak] * ms_multiplier) / 
-                                    self.gui_instance.num_tones))
-
-        # Plot psth with text showing peak-firing rate and onset, peak, offset
-        # latencies
-        self.psth = ax.hist(range(len(self.raw_psth)), weights=self.raw_psth, 
-                            bins=num_bins, alpha=1, color=self.lat_color, 
-                            edgecolor="#fdfdfe", lw=0.4, histtype="stepfilled")
+            return
 
         if self.detailed_plot:
-            self.sdf_line = ax.plot(np.array(self.sdf)*bin_size*self.gui_instance.num_tones, lw=2, 
-                                    color="xkcd:amber")[0]
+            self.on_changes_signal.send()
+            raw = self.model.raw_psth
+            peak_hist = raw.copy()
+            peak_hist[:st.onset] = peak_hist[st.offset:] = 0
+            st.peak = int(np.argmax(peak_hist))
+            st.peak_driven_rate = afunc.get_peak_driven_rate(
+                raw[st.onset:st.offset], self.model.spont_rate,
+                cfg.num_tones)
+            self.latency_txt.set_text(
+                f"{st.onset}, {st.peak}, {st.offset}")
 
-        # If a minimum max y-lim value is set (so small Hz do indeed look 
-        # small), set it IF it is larger than current
-        if min_y:
-            # Convert min_y (in Hz) to # of spikes (ylim value)
-            min_y = (min_y / ms_multiplier) * self.gui_instance.num_tones
-            ylim = ax.get_ylim()
-            if ylim[1] < min_y:
-                ax.set_ylim([0, min_y])
-                y_val = min_y
-            else:
-                y_val = psth_binned[hist_peak]
+        if self.use_lineplot:
+            self.update_line()
+        elif self.use_heatmap:
+            self.update_heatmap()
         else:
-            y_val = psth_binned[hist_peak]
-
-        if self.cf_idx is None:
-            cf_val = "-"
-        else:
-            cf_val = f"{self.gui_instance.frequency[self.cf_idx]/1000:.1f}"
-
-        self.latency_txt = ax.annotate(
-            f"On: {self.onset}, Pk: {self.peak}, Off: {self.offset}\n"
-            f"Rate: {peak_spike_rate} Hz, CF: {cf_val} kHz",
-            (1.25, 0), 
-            xytext=[self.offset+5, y_val], 
-            size=10, 
-            va="top", 
-            name="Segoe UI",
-            weight="bold", 
-            color="xkcd:dark blue")
-
-        ax.set_xlim([0, sweep_length-1])
-
-        # If detailed plot, plot spontaneous and SDF
-        if self.detailed_plot:
-            # Spont was calculated at 1ms bin size
-            spont = (self.spont_rate / 1000) * bin_size * self.gui_instance.num_tones
-            self.spont_line = ax.plot([0, sweep_length-1], [spont, spont], 
-                                      "c", lw=2)[0]
-
-        # Plot latency lines on psth
-        if self.detailed_plot:
-            lat_lw = 3
-        else:
-            lat_lw = 1
-
-        self.onset_line = ax.plot([self.onset, self.onset], [0, y_val],
-                                  "r", lw=lat_lw, picker=2)[0]
-        self.offset_line = ax.plot([self.offset, self.offset], [0, y_val],
-                                   "r", lw=lat_lw, picker=2)[0]
-
-        ax.axis(axis_visible)
+            self.update_bubble()
+        self.figure_canvas.draw()
 
     def off_pick(self):
         """Final UX for user updating latency line."""
-        if self.detailed_plot:
-            lat_lw = 3
-        else:
-            lat_lw = 1
+        lat_lw = 3 if self.detailed_plot else 1
         self.onset_line.set_lw(lat_lw)
-        self.onset_press = 0
         self.offset_line.set_lw(lat_lw)
-        self.offset_press = 0
+        self.onset_press = self.offset_press = False
         if self.detailed_plot:
-            # TODO probably can condense with above, but just testing right now
-            # Update psth with new firing rate / text positions
+            # Full PSTH re-render to reposition the annotation and
+            # refresh the rate text.
             self.psth_plot()
-
         self.figure_canvas.draw()
 
     def pick_cf(self, event):
         """
-        Quick function to let user manually select new cf and threshold from 
-        tuning curve plot based on mouse_click_event..
-        Must do this roundabout way of checking, because ginput() 
-        implementation appears to crash Kivy
+        User clicked the TC plot to set CF/threshold. Snap to the
+        nearest grid index, then seed/clear BW handles according to
+        which rows are still on the grid at the new threshold.
         """
-        # Transform Kivy event coords into figure coords, then check if mouse
-        # event occurs inside axes coords (also transformed into figure 
-        # coords). If event is outside of x or y limits of TC axis, 
-        # return (ignore)
         xdata, ydata = self.ax[1].transData.inverted().transform(
             (event.x, event.y))
-        if (xdata is None) or (ydata is None):
+        if xdata is None or ydata is None:
             return
-        # Update CF and Thresh, and move CF marker to new position
-        self.cf_idx = int(round(xdata))
-        self.thresh_idx = int(round(ydata))
+        cfg = self.model.config
+        st = self.st
+
+        st.cf_idx = int(round(xdata))
+        st.thresh_idx = int(round(ydata))
         if self.cf_marker is None:
-            self.cf_marker = self.ax[1].plot(self.cf_idx, self.thresh_idx, 
+            self.cf_marker = self.ax[1].plot(st.cf_idx, st.thresh_idx,
                                              "r*", ms=8, alpha=0.5)[0]
         else:
-            self.cf_marker.set_xdata([self.cf_idx])
-            self.cf_marker.set_ydata([self.thresh_idx])
-        freq_range = self.gui_instance.num_frequency
-        int_range = self.gui_instance.num_intensity
-        # Any BW whose row now sits above the intensity grid is cleared;
-        # any that's newly in-range but was previously absent gets a wide
-        # default so the user has handles to drag.
-        for lvl in BW_LEVELS:
-            row = self.thresh_idx + lvl // 5  # assumes 5 dB steps — TODO issue #13
-            if row <= int_range:
-                if self.bw_idx[lvl][0] is None:
-                    self.bw_idx[lvl] = [10, freq_range - 10]
-            else:
-                self.bw_idx[lvl] = [None, None]
+            self.cf_marker.set_xdata([st.cf_idx])
+            self.cf_marker.set_ydata([st.thresh_idx])
 
-        # Un-flag picking_cf
+        for lvl in cfg.bw_levels_db:
+            row = st.thresh_idx + cfg.bw_row_offset(lvl)
+            if row < cfg.num_intensity:
+                if st.bw_idx[lvl][0] is None:
+                    st.bw_idx[lvl] = [10, cfg.num_frequency - 10]
+            else:
+                st.bw_idx[lvl] = [None, None]
+
         self.picking_cf = False
-        # Signal that cf was picked
         self.on_cf_pick_signal.send()
         self.on_changes_signal.send()
 
     def pick_bw(self, event):
-        """
-        Bubbles and line plots update y-axis position of bw10-40. Picking a 
-        marker on the end of these lines will allow the user to adjust the 
-        x-axis position of bw's at a site. Similar to pick and move of latency
-        lines.
-        """
-        # TODO currently doesn't do anything to continuous_bw
-        for lvl in BW_LEVELS:
+        """Grab one BW marker for dragging."""
+        for lvl in self.model.config.bw_levels_db:
             markers = self.bw_markers[lvl]
             if markers[0] is None:
                 continue
@@ -2335,23 +2003,22 @@ class SitePlot(RelativeLayout):
                     markers[side].set_ms(12)
                     self.bw_press[lvl][side] = True
                     event.canvas.draw()
-                    return  # one marker at a time
+                    return
 
     def move_bw(self, event_x, event_y):
-        """
-        Drag the currently-held BW marker, clamped to [0, max_freq_idx] and
-        prevented from crossing its partner.
-        """
-        ax_inv = self.ax[1].transData.inverted()
-        xdata, _ = ax_inv.transform((event_x, event_y))
+        """Drag the held BW marker, clamped and non-crossing."""
+        xdata, _ = self.ax[1].transData.inverted().transform(
+            (event_x, event_y))
         if xdata is None:
             return
-        max_idx = self.gui_instance.num_frequency - 1
+        cfg = self.model.config
+        st = self.st
+        max_idx = cfg.num_frequency - 1
 
-        for lvl in BW_LEVELS:
+        for lvl in cfg.bw_levels_db:
             press = self.bw_press[lvl]
             markers = self.bw_markers[lvl]
-            idx = self.bw_idx[lvl]
+            idx = st.bw_idx[lvl]
             if press[0] and xdata < markers[1].get_xdata()[0]:
                 x = max(0, int(round(xdata)))
                 markers[0].set_xdata([x])
@@ -2369,9 +2036,8 @@ class SitePlot(RelativeLayout):
         self.figure_canvas.draw()
 
     def off_bw(self):
-        """Final UX for user updating bandwidth."""
         self.bw_pressed = False
-        for lvl in BW_LEVELS:
+        for lvl in self.model.config.bw_levels_db:
             self.bw_press[lvl] = [False, False]
             if self.bw_markers[lvl][0] is not None:
                 self.bw_markers[lvl][0].set_ms(8)

--- a/src/Field_Selection_GUI.py
+++ b/src/Field_Selection_GUI.py
@@ -44,11 +44,7 @@ from matplotlib.collections import LineCollection
 import warnings
 from matplotlib.axes._axes import _log as matplotlib_axes_logger
 from db_adapter import JSONStore
-
-# dB-above-threshold levels at which bandwidths are measured. The y-offset
-# on the TC plot for each is level // intensity_step (currently 5 dB steps,
-# so BW10 sits 2 rows above threshold, BW20 sits 4 rows above, etc.).
-BW_LEVELS = (10, 20, 30, 40)
+from site_model import SiteModel, StimConfig
 
 # Ignore warnings about opening too many figures or not finding contour lines 
 # issued by matplotlib
@@ -234,7 +230,7 @@ class SiteScreen(Screen):
         densetc_plot.max_bubble_size = 30
         densetc_plot.bubble_plot(axis_visible="on")
         self.densetc_plot = densetc_plot
-        if self.densetc_plot.marked:
+        if self.densetc_plot.model.working.marked:
             self.mark_site_toggle.state = "down"
         self.layout.add_widget(self.densetc_plot)
 
@@ -270,14 +266,11 @@ class SiteScreen(Screen):
 
     def on_mark_toggle(self, _event):
         """Event monitoring if site is 'marked' or not."""
-        if self.mark_site_toggle.state == "down":
-            if not self.densetc_plot.saved_marked:
-                self.densetc_plot.on_changes_signal.send()
-            self.densetc_plot.marked = True
-        else:
-            if self.densetc_plot.saved_marked:
-                self.densetc_plot.on_changes_signal.send()
-            self.densetc_plot.marked = False
+        model = self.densetc_plot.model
+        new_marked = (self.mark_site_toggle.state == "down")
+        if new_marked != model.saved.marked:
+            self.densetc_plot.on_changes_signal.send()
+        model.working.marked = new_marked
 
     def on_reset(self, _event):
         """Event to reset any un-saved analysis changes made to a site."""
@@ -287,38 +280,17 @@ class SiteScreen(Screen):
         self.reset_button.disabled = True
         self.reset_button.background_color = [0.25, 0.05, 0.1, 1]
 
-        # Reset values to default
-        self.densetc_plot.cf_idx = self.densetc_plot.saved_cf_idx
-        self.densetc_plot.thresh_idx = self.densetc_plot.saved_thresh_idx
-        self.densetc_plot.bw_idx = {
-            lvl: v.copy() for lvl, v in self.densetc_plot.saved_bw_idx.items()}
-        self.densetc_plot.continuous_bw_idx = \
-            self.densetc_plot.saved_continuous_bw_idx.copy()
-        self.densetc_plot.onset = self.densetc_plot.saved_onset
-        self.densetc_plot.peak = self.densetc_plot.saved_peak
-        self.densetc_plot.offset = self.densetc_plot.saved_offset
-        self.densetc_plot.peak_driven_rate = \
-            self.densetc_plot.saved_peak_driven_rate
-
-        self.densetc_plot.contour_tc = \
-            self.densetc_plot.saved_contour_tc.copy()
-
+        self.densetc_plot.model.reset()
         self.redraw()
 
         # Reset Marked toggle, if necessary
-        if self.densetc_plot.saved_marked:
-            self.mark_site_toggle.state = "down"
-        else:
-            self.mark_site_toggle.state = "normal"
+        self.mark_site_toggle.state = (
+            "down" if self.densetc_plot.model.saved.marked else "normal")
 
     def change_bin_size(self, _spinner, value):
         """Show PSTH with 1 or 5 ms bin size."""
-        if value == "5 ms":
-            self.densetc_plot.bin_size = 5
-            self.densetc_plot.psth_plot()
-        else:
-            self.densetc_plot.bin_size = 1
-            self.densetc_plot.psth_plot()
+        self.densetc_plot.bin_size = 5 if value == "5 ms" else 1
+        self.densetc_plot.psth_plot()
         self.redraw()
 
     def pick_cf(self, _event):
@@ -336,153 +308,104 @@ class SiteScreen(Screen):
         self.redraw()
 
     def save_changes(self, *_args, **_kwargs):
-        """Update .json storage with new user analysis."""
-        today = str(datetime.datetime.now())
+        """
+        Persist working state to the DB and commit it as the new
+        reset baseline.
+        """
+        model = self.densetc_plot.model
+        st = model.working
+        cfg = model.config
+        freqs = np.asarray(cfg.frequencies_hz)
+        ints = np.asarray(cfg.intensities_db)
+
         self.unsaved_changes = False
         self.save_changes_button.disabled = True
         self.save_changes_button.background_color = [0.2, 0.65, 0, 1]
         self.reset_button.disabled = True
         self.reset_button.background_color = [0.25, 0.05, 0.1, 1]
-        frequencies = self.gui_instance.frequency
-        intensities = self.gui_instance.intensity
 
-        # Copy just in case, to prevent any dangling references
-        continuous_bw = self.densetc_plot.continuous_bw_idx.copy()
-        cf = self.densetc_plot.cf_idx
-        thresh = self.densetc_plot.thresh_idx
-        onset = self.densetc_plot.onset
-        peak = self.densetc_plot.peak
-        offset = self.densetc_plot.offset
-        peak_driven_rate = self.densetc_plot.peak_driven_rate
-        marked = self.densetc_plot.marked
+        if st.continuous_bw_idx[0] is None:
+            # Manual edits were made without re-running auto-analyze,
+            # so continuous BW was never refreshed.
+            result = afunc.ttest_analyze_tuning_curve(model.ttest_tc())
+            st.continuous_bw_idx = result[-2]
 
-        # Update 'saved' values to current values.
-        self.densetc_plot.saved_cf_idx = cf
-        self.densetc_plot.saved_thresh_idx = thresh
-        bw = {lvl: v.copy() for lvl, v in self.densetc_plot.bw_idx.items()}
-        self.densetc_plot.saved_bw_idx = {lvl: v.copy() for lvl, v in bw.items()}
-        self.densetc_plot.saved_continuous_bw_idx = continuous_bw
-        self.densetc_plot.saved_onset = onset
-        self.densetc_plot.saved_peak = peak
-        self.densetc_plot.saved_offset = offset
-        self.densetc_plot.saved_peak_driven_rate = peak_driven_rate
-        self.densetc_plot.saved_marked = marked
-
-        # Finish analysis
+        # Convert indices to physical units
         bw_khz, bw_oct = {}, {}
-        for lvl in BW_LEVELS:
-            if bw[lvl][0] is not None:
-                bw_khz[lvl] = (frequencies[bw[lvl]] / 1000).tolist()
-                bw_oct[lvl] = afunc.get_bandwidth(*frequencies[bw[lvl]]).tolist()
+        for lvl in cfg.bw_levels_db:
+            lo, hi = st.bw_idx[lvl]
+            if lo is not None:
+                bw_khz[lvl] = (freqs[[lo, hi]] / 1000).tolist()
+                bw_oct[lvl] = afunc.get_bandwidth(
+                    freqs[lo], freqs[hi]).tolist()
             else:
                 bw_khz[lvl] = [None, None]
                 bw_oct[lvl] = None
 
-        if continuous_bw[0] is None:  
-            # Site is being saved with new data, but cont. BW's haven't updated
-            ttest_spike_counts = afunc.get_driven_vs_spont_spike_counts(
-                self.densetc_plot.tuning_curve_df,
-                driven_onset_ms=onset, 
-                driven_offset_ms=offset,
-                spont_onset_ms=400 - (offset - onset),
-                spont_offset_ms=400)
-            _, _, cf, thresh, *bws, continuous_bw, _ = \
-                afunc.ttest_analyze_tuning_curve(
-                     afunc.ttest_driven_vs_spont_tc(*ttest_spike_counts))
-            bw = dict(zip(BW_LEVELS, bws))
-        try:  
-            # Cont. BW should work now, but rare cases may still create an 
-            # exception (eg. no regions found in auto-tc)
-            continuous_bw_khz = [(frequencies[bw] / 1000).tolist() for 
-                                 bw in continuous_bw]
-            continuous_bw_octave = [
-                afunc.get_bandwidth(*frequencies[bw]).tolist() for 
-                bw in continuous_bw]
-        except TypeError:  
-            # Cont. BW is likely [None, None] for some reason or other. 
-            # In this case, leave it that way
-            continuous_bw = [None, None]
-            continuous_bw_khz = [None, None]
-            continuous_bw_octave = None
-
-        cf_khz = frequencies[cf] / 1000
-        thresh_db = intensities[thresh].tolist()
-
-        analysis_id = self.gui_instance.analysis_id
-        site_number = self.map_number
+        try:
+            cont_bw_khz = [(freqs[b] / 1000).tolist()
+                           for b in st.continuous_bw_idx]
+            cont_bw_oct = [afunc.get_bandwidth(*freqs[b]).tolist()
+                           for b in st.continuous_bw_idx]
+        except TypeError:
+            # Auto-analysis found no regions; persist as absent.
+            st.continuous_bw_idx = [None, None]
+            cont_bw_khz = [None, None]
+            cont_bw_oct = None
+        
+        # Guard cf/thresh against None
+        cf_khz = (None if st.cf_idx is None 
+                  else freqs[st.cf_idx] / 1000)
+        threshold_db = (None if st.thresh_idx is None 
+                        else ints[st.thresh_idx].tolist())
         update_doc = {
             "cf_khz": cf_khz,
-            "threshold_db": thresh_db,
-            "cf_idx": cf,
-            "threshold_idx": thresh,
-            "continuous_bw_khz": continuous_bw_khz,
-            "continuous_bw_idx": continuous_bw,
-            "continuous_bw_octave": continuous_bw_octave,
-            "onset_ms": onset,
-            "peak_ms": peak,
-            "offset_ms": offset,
-            "peak_driven_rate_hz": peak_driven_rate,
-            "marked": marked,
+            "threshold_db": threshold_db,
+            "cf_idx": st.cf_idx,
+            "threshold_idx": st.thresh_idx,
+            "continuous_bw_khz": cont_bw_khz,
+            "continuous_bw_idx": st.continuous_bw_idx,
+            "continuous_bw_octave": cont_bw_oct,
+            "onset_ms": st.onset,
+            "peak_ms": st.peak,
+            "offset_ms": st.offset,
+            "peak_driven_rate_hz": st.peak_driven_rate,
+            "marked": st.marked,
         }
-        for lvl in BW_LEVELS:
-            update_doc[f"bw{lvl}_idx"] = bw[lvl]
+        for lvl in cfg.bw_levels_db:
+            update_doc[f"bw{lvl}_idx"] = st.bw_idx[lvl]
             update_doc[f"bw{lvl}_khz"] = bw_khz[lvl]
             update_doc[f"bw{lvl}_octave"] = bw_oct[lvl]
 
         self.gui_instance.densetc_analysis_collection.update_one(
-            {"analysis_id": analysis_id, "number": site_number},
-            {"$set": update_doc})
+            {"analysis_id": self.gui_instance.analysis_id,
+             "number": self.map_number},
+            {"$set": update_doc}
+        )
 
         self.gui_instance.analysis_metadata_collection.update_one(
-            {"_id": analysis_id},
-            {"$set": {
-                "last_modified": today
-            }})
+            {"_id": self.gui_instance.analysis_id},
+            {"$set": {"last_modified": str(datetime.datetime.now())}}
+        )
 
-        # Update plots with correct colors / values
-        self.densetc_plot.bubble_color = self.densetc_plot.cf_cmap(
-            self.densetc_plot.norm(self.densetc_plot.cf_idx))
-        self.densetc_plot.lat_color = self.densetc_plot.speed_cmap(
-            self.densetc_plot.speed_norm(self.densetc_plot.onset))
+        model.commit()
         self.redraw()
 
-        self.gui_instance.plot_dict[self.map_number].cf_idx = cf
-        self.gui_instance.plot_dict[self.map_number].thresh_idx = thresh
-        self.gui_instance.plot_dict[self.map_number].onset = onset
-        self.gui_instance.plot_dict[self.map_number].peak = peak
-        self.gui_instance.plot_dict[self.map_number].offset = offset
-        self.gui_instance.plot_dict[self.map_number].bw_idx = \
-            {lvl: v.copy() for lvl, v in bw.items()}
-        self.gui_instance.plot_dict[self.map_number].bubble_color = \
-            self.densetc_plot.bubble_color
-        self.gui_instance.plot_dict[self.map_number].lat_color = \
-            self.densetc_plot.lat_color
-        self.gui_instance.plot_dict[self.map_number].re_plot()
-
     def auto_tc_analyze(self, *_args, **_kwargs):
-        """Run TC auto-analysis; use after manually updating PSTH latencies."""
-        onset = self.densetc_plot.onset
-        offset = self.densetc_plot.offset
+        """
+        Re-run the TC auto-analysis at the current latency window and
+        load results into working state. Nothing persists until Save.
+        """
+        model = self.densetc_plot.model
+        st = model.working
+        cfg = model.config
         self.densetc_plot.on_changes_signal.send()
-        ttest_spike_counts = afunc.get_driven_vs_spont_spike_counts(
-            self.densetc_plot.tuning_curve_df,
-            driven_onset_ms=onset, 
-            driven_offset_ms=offset,
-            spont_onset_ms=400 - (offset - onset),
-            spont_offset_ms=400)
-        smooth_tc, _, cf, thresh, *bws, continuous_bw, _ = \
-            afunc.ttest_analyze_tuning_curve(
-                afunc.ttest_driven_vs_spont_tc(*ttest_spike_counts))
-
-        # Store analyzed data in the SitePlot object. 
-        # Data is NOT saved until user hits 'Save' button
-        self.densetc_plot.cf_idx = cf
-        self.densetc_plot.thresh_idx = thresh
-        self.densetc_plot.bw_idx = dict(zip(BW_LEVELS, bws))
-        self.densetc_plot.continuous_bw_idx = continuous_bw
-        smooth_tc[0 < smooth_tc] = 1
-        self.densetc_plot.contour_tc = smooth_tc
-
+        _, _, cf, thresh, *bws, continuous_bw, _ = \
+            afunc.ttest_analyze_tuning_curve(model.ttest_tc())
+        st.cf_idx = cf
+        st.thresh_idx = thresh
+        st.bw_idx = dict(zip(cfg.bw_levels_db, bws))
+        st.continuous_bw_idx = continuous_bw
         self.redraw()
 
     def changes_made(self, *_args, **_kwargs):
@@ -502,30 +425,20 @@ class SiteScreen(Screen):
     def change_screen(self, _event):
         """
         Close Site-specific screen and return to Map GUI overview.
-        Updates latency lines and plots with any user analysis changes, and 
-        marks whether a site is 'Marked' or has unsaved user changes.
-        Triggers event to briefly flash Site in Map GUI to help user navigate
-        where they were just inspecting.
+        Updates persist between views.
         """
-        xdata_onset = self.densetc_plot.onset_line.get_xdata()
-        xdata_offset = self.densetc_plot.offset_line.get_xdata()
-        self.gui_instance.plot_dict[
-            self.map_number].onset_line.set_xdata(xdata_onset)
-        self.gui_instance.plot_dict[
-            self.map_number].offset_line.set_xdata(xdata_offset)
-        self.gui_instance.plot_dict[
-            self.map_number].onset = self.densetc_plot.onset
-        self.gui_instance.plot_dict[
-            self.map_number].offset = self.densetc_plot.offset
-        self.gui_instance.plot_dict[self.map_number].update_bubble()
+        overview = self.gui_instance.plot_dict[self.map_number]
+        overview.re_plot()
         try:
-            self.gui_instance.plot_dict[self.map_number].figure_canvas.draw()
-        except ValueError: # Raised by non-responsive sites -- just ignore. 
+            overview.figure_canvas.draw()
+        except ValueError:
+            # Non-responsive sites occasionally raise on draw; harmless.
             pass
-        
-        self.flash_signal.send(self.map_number, 
-                               unsaved_changes=self.unsaved_changes, 
-                               marked=self.densetc_plot.marked)
+
+        self.flash_signal.send(
+            self.map_number,
+            unsaved_changes=self.unsaved_changes,
+            marked=self.densetc_plot.model.working.marked)
         self.densetc_plot.active = False
         self.densetc_plot.fig.clf()
         self.manager.switch_to(self.gui_instance.parent)
@@ -533,7 +446,6 @@ class SiteScreen(Screen):
     def on_pre_enter(self, *args):
         """Ready Site plots prior to switching GUI screens."""
         self.densetc_plot.active = True
-        # Clear first plot generated during SitePlot.__init__()
         self.densetc_plot.fig.clf()
         self.densetc_plot.ax[0] = self.densetc_plot.fig.add_subplot(2, 1, 1)
         self.densetc_plot.ax[1] = self.densetc_plot.fig.add_subplot(2, 1, 2)

--- a/src/Field_Selection_GUI.py
+++ b/src/Field_Selection_GUI.py
@@ -502,6 +502,8 @@ class FieldSelectionGUI(BoxLayout):
 
         self.counter = 0
         self.site_screens = {}
+        self.site_models = {}
+        self.stim_config = None
 
         self.vor_df = None
         self.dense_df = None
@@ -782,6 +784,13 @@ class FieldSelectionGUI(BoxLayout):
                 a["number"]: a
                 for a in self.densetc_analysis_collection.find(
                     {"analysis_id": self.analysis_id})}
+            
+            # One StimConfig shared by every SiteModel. Sweep length is
+            # sniffed from a PSTH if the project config doesn't carry it.
+            any_analysis = next(iter(self.densetc_analysis.values()))
+            self.stim_config = StimConfig.from_project_config(
+                self.project_configuration,
+                fallback_sweep_ms=len(any_analysis["psth"]))
 
             self.display_map()
             print("\n *** Ready! *** \n")
@@ -808,9 +817,23 @@ class FieldSelectionGUI(BoxLayout):
     def open_site_screen(self, site_number):
         """
         Switch from the Map overview to the detailed analysis view for a site.
-
+        Built on the fly when first accessed.
         `self.parent` is the MapScreen that owns this layout.
         """
+        if site_number not in self.site_screens:
+            detail_plot = SitePlot(
+                model=self.site_models[site_number],
+                detailed_plot=True,
+                is_ic=self.ic_bool,
+                cf_cmap=self.cf_colormap_dropdown.text,
+                heatmap_cmap=self.heatmap_colormap_dropdown.text,
+                size_hint=(1, 1),
+                pos_hint={"center_x": 0.5, "center_y": 0.5},
+                height=1,
+                width=2)
+            self.site_screens[site_number] = SiteScreen(
+                self, site_number, detail_plot,
+                name=f"Site {site_number}")
         self.parent.manager.switch_to(self.site_screens[site_number])
 
     def on_cf_colormap(self, _spinner, value):
@@ -1124,31 +1147,25 @@ class FieldSelectionGUI(BoxLayout):
             y = (site["voronoi_centroid"][1] * 
                  (reduced_scale[1] - reduced_scale[0]) / 
                  (1 - 0) + reduced_scale[0])
+            
+            model = SiteModel(site_number,
+                              self.densetc_data[site_number],
+                              site_analysis,
+                              self.stim_config)
+            self.site_models[site_number] = model
             site_plot = SitePlot(
+                model=model,
+                detailed_plot=False,
+                is_ic=self.ic_bool,
+                cf_cmap=self.cf_colormap_dropdown.text,
+                heatmap_cmap=self.heatmap_colormap_dropdown.text,
                 size_hint=(None, None), 
                 pos_hint={"center_x": x, "center_y": y},
                 height=150, 
-                width=200, 
-                site_number=site_number,
-                gui_instance=self,
-                detailed_plot=False, 
-                cf_cmap=self.cf_colormap_dropdown.text,
-                heatmap_cmap=self.heatmap_colormap_dropdown.text)
-            detail_plot = SitePlot(
-                size_hint=(1, 1), 
-                pos_hint={"center_x": 0.5, "center_y": 0.5},
-                height=1, 
-                width=2,
-                site_number=site_number, 
-                gui_instance=self,
-                detailed_plot=True, 
-                cf_cmap=self.cf_colormap_dropdown.text,
-                heatmap_cmap=self.heatmap_colormap_dropdown.text)
+                width=200)
 
             self.plot_dict[site_number] = site_plot
             self.map_canvas.add_widget(site_plot)
-            self.site_screens[site_number] = SiteScreen(
-                self, site_number, detail_plot, name=f"Site {site_number}")
             with self.map_canvas.canvas.before:
                 # Check if site should start painted some color
                 if site_analysis["field_assignment"] and not self.marks_active:

--- a/src/site_model.py
+++ b/src/site_model.py
@@ -1,0 +1,236 @@
+"""
+Per-site data model, decoupled from the Kivy widgets that render it.
+
+One SiteModel per recording site. The overview plots and the detail
+view hold a reference to the same model, so building the tuning curve
+DataFrame happens once per site instead of once per widget.
+
+Caching policy:
+  - tuning_curve_df is the only cached_property. It's built from raw
+    spiketrains; nothing the user does can change it.
+  - raw_tc / ttest_tc / contour_tc are functions of (onset, offset).
+    Each carries a one-slot memo keyed on that pair, so toggling display
+    mode or picking CF (redraws that don't touch latencies) are cache
+    hits. Dragging a latency line changes the key and forces a
+    recompute. No invalidation code anywhere since the key mismatch does it.
+"""
+from dataclasses import dataclass, field
+from functools import cached_property
+from copy import deepcopy
+import numpy as np
+import pandas as pd
+import analysis_functions as afunc
+
+
+@dataclass(frozen=True)
+class StimConfig:
+    """
+    Stimulus / recording parameters. Replaces hard-coded values scattered 
+    through Field_Selection_GUI (400 ms sweep len, dB steps, etc). Built once
+    from project_configuration in _load() and treated as read-only.
+    """
+    frequencies_hz: tuple
+    intensities_db: tuple
+    num_tones: int
+    sweep_length_ms: int
+    bw_levels_db: tuple = field(default_factory=lambda: (10, 20, 30, 40))
+
+    def __post_init__(self):
+        object.__setattr__(self, "frequencies_hz", tuple(self.frequencies_hz))
+        object.__setattr__(self, "intensities_db", tuple(self.intensities_db))
+        object.__setattr__(self, "bw_levels_db", tuple(self.bw_levels_db))
+
+    @property
+    def num_frequency(self):
+        return len(self.frequencies_hz)
+
+    @property
+    def num_intensity(self):
+        return len(self.intensities_db)
+
+    @cached_property
+    def intensity_step_db(self):
+        """
+        Spacing between intensity levels, used to turn a BW level (e.g.
+        20 dB above threshold) into a row offset on the TC grid. The
+        stimulus has always been uniformly spaced; if that stops being
+        true, bw_row_offset needs to become a searchsorted lookup.
+        """
+        steps = np.diff(self.intensities_db)
+        if len(steps) == 0:
+            return 1
+        if not np.allclose(steps, steps[0]):
+            raise ValueError(
+                f"Non-uniform intensity steps {steps}; "
+                "BW row positioning assumes uniform spacing.")
+        return int(steps[0])
+
+    def bw_row_offset(self, level_db):
+        q, r = divmod(level_db, self.intensity_step_db)
+        if r != 0:
+            raise ValueError(
+                f"BW level {level_db} dB does not align with "
+                f"{self.intensity_step_db} dB intensity spacing.")
+        return q
+
+    def spont_window(self, onset_ms, offset_ms):
+        """
+        (spont_start, spont_end) — same-length window at the tail of the
+        sweep. Replaces the `400 - (offset - onset)` expression pasted at
+        every remove_spont / get_driven_vs_spont call site.
+        """
+        driven = offset_ms - onset_ms
+        if driven < 0:
+            raise ValueError(
+                f"offset_ms must be >= onset_ms, got {offset_ms} < {onset_ms}")
+        if driven > self.sweep_length_ms:
+            raise ValueError(
+                f"Driven window {driven} ms exceeds sweep length "
+                f"{self.sweep_length_ms} ms")
+        return self.sweep_length_ms - driven, self.sweep_length_ms
+
+    @classmethod
+    def from_project_config(cls, cfg, fallback_sweep_ms=None):
+        # Prefer an explicit config key; fall back to whatever the caller
+        # sniffed (e.g. len(psth)); then the historical default. Add
+        # densetc_sweep_length_ms to new analysis_metadata docs going
+        # forward and this fallback stops mattering.
+        sweep = cfg.get("densetc_sweep_length_ms") or fallback_sweep_ms or 400
+        return cls(
+            frequencies_hz=sorted(cfg["densetc_frequency_hz"]),
+            intensities_db=sorted(cfg["densetc_intensity_db"]),
+            num_tones=cfg["densetc_num_tones"],
+            sweep_length_ms=sweep,
+        )
+
+
+@dataclass(slots=True)
+class AnalysisState:
+    """
+    Mutable per-site analysis values (written back to the DB on save).
+        model.working is what the user edits
+        model.saved is the last committed snapshot
+        reset/commit become one-liners.
+    """
+    cf_idx: int
+    thresh_idx: int
+    onset: int
+    offset: int
+    peak: int
+    peak_driven_rate: float
+    bw_idx: dict  # {level_db: [lo, hi] or [None, None]}
+    continuous_bw_idx: list
+    marked: bool
+
+    def copy(self):
+        return deepcopy(self)
+
+    @classmethod
+    def from_db(cls, doc, bw_levels):
+        return cls(
+            cf_idx=doc["cf_idx"],
+            thresh_idx=doc["threshold_idx"],
+            onset=doc["onset_ms"],
+            offset=doc["offset_ms"],
+            peak=doc["peak_ms"],
+            peak_driven_rate=doc["peak_driven_rate_hz"],
+            bw_idx={lvl: list(doc[f"bw{lvl}_idx"]) for lvl in bw_levels},
+            continuous_bw_idx=list(doc["continuous_bw_idx"]),
+            marked=doc.get("marked", False),  # absent in pre-mark analyses
+        )
+
+
+class SiteModel:
+    def __init__(self, site_number, data_doc, analysis_doc, config):
+        self.site_number = site_number
+        self.config = config
+        self._data_doc = data_doc
+
+        self.raw_psth = np.asarray(analysis_doc["psth"])
+        self.spont_rate = analysis_doc["spont_firing_rate_hz"]
+        self.sdf = np.asarray(analysis_doc.get("bb_sdf", 0))  # absent pre-SDF
+
+        self.saved = AnalysisState.from_db(analysis_doc, config.bw_levels_db)
+        self.working = self.saved.copy()
+
+        # One-slot memos: ((onset, offset), array). See module docstring.
+        self._raw_tc_cache = (None, None)
+        self._ttest_tc_cache = (None, None)
+        self._contour_cache = (None, None)
+
+    @cached_property
+    def tuning_curve_df(self):
+        site_df = pd.DataFrame(self._data_doc["spiketrains"])
+        return afunc.get_tuning_curve_dataframe(site_df)
+
+    def _window(self, onset, offset):
+        on = self.working.onset if onset is None else onset
+        off = self.working.offset if offset is None else offset
+
+        if on < 0:
+            raise ValueError(f"onset must be >= 0, got {on}")
+        if off < on:
+            raise ValueError(
+                f"offset must be >= onset, got onset={on}, offset={off}")
+        if off > self.config.sweep_length_ms:
+            raise ValueError(
+                f"offset {off} exceeds sweep length "
+                f"{self.config.sweep_length_ms}")
+
+        return on, off
+
+    def raw_tc(self, onset=None, offset=None):
+        # TODO This should be reworked to allow *actual* raw, and then the
+        # spont-adjusted one for analysis views separate
+        """Spont-subtracted spike counts per (intensity, frequency)."""
+        key = self._window(onset, offset)
+        if self._raw_tc_cache[0] == key:
+            return self._raw_tc_cache[1]
+
+        on, off = key
+        s_on, s_off = self.config.spont_window(on, off)
+        def per_cell(x):
+            if x is None or np.any(np.isnan(x)):
+                return 0
+            return afunc.remove_spont(
+                x, driven_onset_ms=on, driven_offset_ms=off,
+                spont_onset_ms=s_on, spont_offset_ms=s_off)
+        arr = np.asarray(self.tuning_curve_df.map(per_cell), dtype=np.uint16)
+
+        self._raw_tc_cache = (key, arr)
+        return arr
+
+    def ttest_tc(self, onset=None, offset=None):
+        """Smoothed (t-test) TC at the given window."""
+        key = self._window(onset, offset)
+        if self._ttest_tc_cache[0] == key:
+            return self._ttest_tc_cache[1]
+
+        on, off = key
+        s_on, s_off = self.config.spont_window(on, off)
+        counts = afunc.get_driven_vs_spont_spike_counts(
+            self.tuning_curve_df,
+            driven_onset_ms=on, driven_offset_ms=off,
+            spont_onset_ms=s_on, spont_offset_ms=s_off)
+        arr = afunc.ttest_driven_vs_spont_tc(*counts)
+
+        self._ttest_tc_cache = (key, arr)
+        return arr
+
+    def contour_tc(self, onset=None, offset=None):
+        """Binary mask for the contour overlay"""
+        key = self._window(onset, offset)
+        if self._contour_cache[0] == key:
+            return self._contour_cache[1]
+
+        smooth = afunc.ttest_analyze_tuning_curve(self.ttest_tc(*key))[0]
+        smooth[smooth > 0] = 1
+
+        self._contour_cache = (key, smooth)
+        return smooth
+
+    def reset(self):
+        self.working = self.saved.copy()
+
+    def commit(self):
+        self.saved = self.working.copy()


### PR DESCRIPTION
Much of the plotting logic and rendering operations were unnecessarily duplicated, making the code harder to read and reason through, and significantly slowing down the initial map loading process.

This PR introduces a new module, `site_model`, that contains classes for handling stimulus configuration, site data, and site analysis. The config enables removal of several hard-coded stimulus params (related to #13), and the explicit analysis state class makes save/reset much cleaner.

Detail plots, smooth-tc, and contours are now lazy loaded, speeding up initial app launch (related to #36), and a memo improves re-drawing speed when onset/offset don't change between re-renders.

Resolves #9, closes #11 

#35 is left as a quick clean up job for another PR, since it is low priority.