### PR TITLE
Refactor/loop bw

### DIFF
--- a/src/Field_Selection_GUI.py
+++ b/src/Field_Selection_GUI.py
@@ -327,20 +327,11 @@ class SiteScreen(Screen):
         if st.continuous_bw_idx[0] is None:
             # Manual edits were made without re-running auto-analyze,
             # so continuous BW was never refreshed.
-            result = afunc.ttest_analyze_tuning_curve(model.ttest_tc())
-            st.continuous_bw_idx = result[-2]
+            st.continuous_bw_idx = afunc.ttest_analyze_tuning_curve(
+                model.ttest_tc()).continuous_bw
 
         # Convert indices to physical units
-        bw_khz, bw_oct = {}, {}
-        for lvl in cfg.bw_levels_db:
-            lo, hi = st.bw_idx[lvl]
-            if lo is not None:
-                bw_khz[lvl] = (freqs[[lo, hi]] / 1000).tolist()
-                bw_oct[lvl] = afunc.get_bandwidth(
-                    freqs[lo], freqs[hi]).tolist()
-            else:
-                bw_khz[lvl] = [None, None]
-                bw_oct[lvl] = None
+        bw_khz, bw_oct = afunc.bw_idx_to_units(st.bw_idx, freqs)
 
         try:
             cont_bw_khz = [(freqs[b] / 1000).tolist()
@@ -400,12 +391,11 @@ class SiteScreen(Screen):
         st = model.working
         cfg = model.config
         self.densetc_plot.on_changes_signal.send()
-        _, _, cf, thresh, *bws, continuous_bw, _ = \
-            afunc.ttest_analyze_tuning_curve(model.ttest_tc())
-        st.cf_idx = cf
-        st.thresh_idx = thresh
-        st.bw_idx = dict(zip(cfg.bw_levels_db, bws))
-        st.continuous_bw_idx = continuous_bw
+        r = afunc.ttest_analyze_tuning_curve(model.ttest_tc())
+        st.cf_idx = r.cf
+        st.thresh_idx = r.thresh
+        st.bw_idx = r.bw_idx
+        st.continuous_bw_idx = r.continuous_bw
         self.redraw()
 
     def changes_made(self, *_args, **_kwargs):

--- a/src/analysis_functions.py
+++ b/src/analysis_functions.py
@@ -448,30 +448,32 @@ def check_csv_points(points_df):
     plt.show()
 
 
+def snap_idx(grid_vals, input_value, allow_zero=True):
+    """
+    Index into `grid_vals` of the entry closest to `input_value`.
+    Same allow_zero convention as snap(); returns None when triggered.
+    """
+    if input_value == 0 and not allow_zero:
+        return None
+    ix = bisect.bisect_right(grid_vals, input_value)
+    if ix == 0:
+        return 0
+    if ix == len(grid_vals):
+        return ix - 1
+    lo, hi = grid_vals[ix - 1], grid_vals[ix]
+    return ix - 1 if abs(lo - input_value) <= abs(hi - input_value) else ix
+
+
 def snap(grid_vals, input_value, allow_zero=True):
     """
-    Useful function to snap any cf, thresh, BW's, freq or int to nearest values 
-      of known input, grid_vals.
-      eg. grid_vals is list of possible frequencies, 
-          input_val is frequency slightly off from grid of possible vals.
-          
     Returns the value in grid_vals that input_value is closest to.
-    
+
     Idiosyncrasy: 'final file' values use 0 to indicate a null value. 
       To deal with this and properly return a null value instead of a snapped 
       value, pass keyword argument allow_zero=False.
-    """
-    if (input_value == 0) and (allow_zero is False):
-        return None
-
-    ix = bisect.bisect_right(grid_vals, input_value)
-    if ix == 0:
-        return grid_vals[0]
-    elif ix == len(grid_vals):
-        return grid_vals[-1]
-    else:
-        return min(grid_vals[ix - 1], grid_vals[ix], 
-                   key=lambda grid_value: abs(grid_value - input_value))
+      """
+    idx = snap_idx(grid_vals, input_value, allow_zero)
+    return None if idx is None else grid_vals[idx]
 
 
 def scale_coordinates(input_coor, min_coor, max_coor, min_scale, max_scale):

--- a/src/analysis_functions.py
+++ b/src/analysis_functions.py
@@ -26,7 +26,36 @@ from scipy.spatial import Voronoi
 from scipy.stats import ttest_ind
 from db_adapter import JSONStore
 import cli_utils as cli
+from collections import namedtuple
 
+# dB-above-threshold levels at which bandwidths are measured. Mirrors
+# StimConfig.bw_levels_db;
+# TODO this is just temp solution that'll be subsumed by a more complete refactor
+BW_LEVELS = (10, 20, 30, 40)
+
+TCResult = namedtuple(
+    "TCResult",
+    "tc_image filtered_tc cf thresh bw_idx continuous_bw convex_image"
+)
+
+def bw_idx_to_units(bw_idx, freqs_hz):
+    """
+    Convert {level: [lo_idx, hi_idx]} index pairs into physical units.
+
+    Returns (khz, octave) dicts keyed identically to `bw_idx`.
+    Absent levels ([None, None]) map to [None, None] and None.
+    """
+    freqs_hz = np.asarray(freqs_hz)
+    khz, octave = {}, {}
+    for lvl, idx in bw_idx.items():
+        if idx[0] is None:
+            khz[lvl] = [None, None]
+            octave[lvl] = None
+        else:
+            lo, hi = idx
+            khz[lvl] = (freqs_hz[[lo, hi]] / 1000).tolist()
+            octave[lvl] = get_bandwidth(freqs_hz[lo], freqs_hz[hi]).tolist()
+    return khz, octave
 
 def get_folder(**kwargs):
     """
@@ -1281,34 +1310,21 @@ def ttest_analyze_tuning_curve(tc_array):
         non_tc_ind = np.where(med_label != [med_regions[big_r].label])
         tc_im_copy[non_tc_ind] = 0
         cf = int(np.argmax(tc_im_copy[med_minr, :]))
-        # Get final_file-style BW's; assign None to any of 10-40 if they exceed
-        # range of intensity.
-        # Using tolist() to make data JSON-serializable
-        # Using convex_image instead of TC to smooth jagged edges of blur and 
-        # produce more consistent contours
         cvx_im = tc_im_copy.copy()
         cvx_im[med_minr:med_maxr, med_minc:med_maxc] = \
             med_regions[big_r].convex_image
-        try:
-            response_idx = np.where(tc_im_copy[med_minr + 2, :])
-            bw10 = np.array([response_idx[0][0], response_idx[0][-1]]).tolist()
-        except IndexError:
-            bw10 = [None, None]
-        try:
-            response_idx = np.where(tc_im_copy[med_minr + 4, :])
-            bw20 = np.array([response_idx[0][0], response_idx[0][-1]]).tolist()
-        except IndexError:
-            bw20 = [None, None]
-        try:
-            response_idx = np.where(tc_im_copy[med_minr + 6, :])
-            bw30 = np.array([response_idx[0][0], response_idx[0][-1]]).tolist()
-        except IndexError:
-            bw30 = [None, None]
-        try:
-            response_idx = np.where(tc_im_copy[med_minr + 8, :])
-            bw40 = np.array([response_idx[0][0], response_idx[0][-1]]).tolist()
-        except IndexError:
-            bw40 = [None, None]
+
+        # BW at each level: first/last responsive column at the row
+        # `level/5` steps above threshold. Row off the grid → absent.
+        # The /5 assumes 5 dB intensity spacing; 
+        # TODO future PR will wire StimConfig so this becomes cfg.bw_row_offset(lvl).
+        bw_idx = {}
+        for lvl in BW_LEVELS:
+            try:
+                cols = np.where(tc_im_copy[med_minr + lvl // 5, :])[0]
+                bw_idx[lvl] = [int(cols[0]), int(cols[-1])]
+            except IndexError:
+                bw_idx[lvl] = [None, None]
 
         # Get continuous BWs
         cont_bw = []
@@ -1329,18 +1345,16 @@ def ttest_analyze_tuning_curve(tc_array):
         # If latency found, but no region is found (rare/impossible, yes?), 
         # don't assign cf, thresh, or bw's
         thresh = cf = None
-        bw10 = bw20 = bw30 = bw40 = [None, None]
+        bw_idx = {lvl: [None, None] for lvl in BW_LEVELS}
         cont_bw = [None]
         tc_im_copy = tc_array  # Just return image (should be empty).
         cvx_im = tc_array
 
     filtered_tc = tc_array.copy()
     filtered_tc[~med_binary] = 0
-    result = (tc_im_copy, filtered_tc, cf, thresh, bw10, bw20, bw30, bw40, 
-              cont_bw, cvx_im)
+    return TCResult(tc_im_copy, filtered_tc, cf, thresh, bw_idx,
+                    cont_bw, cvx_im)
     
-    return result
-
 
 def create_final_file(ic_bool=False):
     """
@@ -1358,6 +1372,9 @@ def create_final_file(ic_bool=False):
     # Initialize length of final-file matrix. Currently 88 from MATLAB vplot
     # style, but arbitrary
     array_length = 88
+
+    # Starting column for each BW triple (a, b, octave) in v-plot layout.
+    BW_FF_COLS = {10: 6, 20: 11, 30: 16, 40: 21}
 
     # Initialize database
     subject_database = JSONStore(db_path)
@@ -1442,45 +1459,18 @@ def create_final_file(ic_bool=False):
         spont = analysis_entry["spont_firing_rate_hz"]
 
         if analysis_entry["cf_idx"] is None:
-            cf = 0
-            thresh = 0
-            a10 = b10 = bw10 = 0
-            a20 = b20 = bw20 = 0
-            a30 = b30 = bw30 = 0
-            a40 = b40 = bw40 = 0
-            onset = offset = peak = 0
-            peak_driven_rate = 0
+            cf = thresh = onset = offset = peak = peak_driven_rate = 0
         else:
             cf = analysis_entry["cf_khz"]
             thresh = analysis_entry["threshold_db"]
-            if analysis_entry["bw10_idx"][0] is not None:
-                bw10_khz = analysis_entry["bw10_khz"]
-                bw10_octave = analysis_entry["bw10_octave"]
-                a10, b10 = bw10_khz
-                bw10 = bw10_octave
-            else:
-                a10 = b10 = bw10 = 0
-            if analysis_entry["bw20_idx"][0] is not None:
-                bw20_khz = analysis_entry["bw20_khz"]
-                bw20_octave = analysis_entry["bw20_octave"]
-                a20, b20 = bw20_khz
-                bw20 = bw20_octave
-            else:
-                a20 = b20 = bw20 = 0
-            if analysis_entry["bw30_idx"][0] is not None:
-                bw30_khz = analysis_entry["bw30_khz"]
-                bw30_octave = analysis_entry["bw30_octave"]
-                a30, b30 = bw30_khz
-                bw30 = bw30_octave
-            else:
-                a30 = b30 = bw30 = 0
-            if analysis_entry["bw40_idx"][0] is not None:
-                bw40_khz = analysis_entry["bw40_khz"]
-                bw40_octave = analysis_entry["bw40_octave"]
-                a40, b40 = bw40_khz
-                bw40 = bw40_octave
-            else:
-                a40 = b40 = bw40 = 0
+            for lvl in BW_LEVELS:
+                if analysis_entry[f"bw{lvl}_idx"][0] is None:
+                    continue  # final_file row is already zero
+                a, b = analysis_entry[f"bw{lvl}_khz"]
+                col = BW_FF_COLS[lvl]
+                final_file[idx, col]     = a
+                final_file[idx, col + 1] = b
+                final_file[idx, col + 2] = analysis_entry[f"bw{lvl}_octave"]
 
             onset = analysis_entry["onset_ms"]
             peak = analysis_entry["peak_ms"]
@@ -1491,18 +1481,6 @@ def create_final_file(ic_bool=False):
         final_file[idx, 0] = file_number
         final_file[idx, 1] = cf
         final_file[idx, 2] = thresh
-        final_file[idx, 6] = a10
-        final_file[idx, 7] = b10
-        final_file[idx, 8] = bw10
-        final_file[idx, 11] = a20
-        final_file[idx, 12] = b20
-        final_file[idx, 13] = bw20
-        final_file[idx, 16] = a30
-        final_file[idx, 17] = b30
-        final_file[idx, 18] = bw30
-        final_file[idx, 21] = a40
-        final_file[idx, 22] = b40
-        final_file[idx, 23] = bw40
         final_file[idx, 25] = onset
         final_file[idx, 26] = peak_driven_rate
         final_file[idx, 33] = peak

--- a/src/densetc_analysis.py
+++ b/src/densetc_analysis.py
@@ -480,10 +480,10 @@ def densetc_bw_loop(idx, file, total, use_f32, n_sweeps, freqs, ints,
         else:
             # Snap variable final file analysis values to true values
             # eg. Threshold of 10.7 dB snaps to 10 dB
-            cf_khz = afunc.snap(freqs/1000, row["cf"].values)
-            thresh_db = int(afunc.snap(ints, row["thresh"].values))
-            cf = int(np.where(int(cf_khz*1000) == freqs.astype(int))[0][0])
-            thresh = int(np.where(thresh_db == ints)[0][0])
+            cf = afunc.snap_idx(freqs / 1000, row["cf"].values)
+            cf_khz = freqs[cf] / 1000
+            thresh = afunc.snap_idx(ints, row["thresh"].values)
+            thresh_db = ints[thresh]
             
         bw_idx, bw_khz, bw_oct = {}, {}, {}
         for lvl in BW_LEVELS:

--- a/src/densetc_analysis.py
+++ b/src/densetc_analysis.py
@@ -13,6 +13,7 @@ import analysis_functions as afunc
 from functools import partial
 from db_adapter import JSONStore
 import cli_utils as cli
+from analysis_functions import BW_LEVELS, bw_idx_to_units
 
 os.environ["RAY_DEDUP_LOGS"] = "0"
 import ray
@@ -464,12 +465,10 @@ def densetc_bw_loop(idx, file, total, use_f32, n_sweeps, freqs, ints,
     if latency_dict["peak"] is None:  # Non-responsive site, no analysis needed
         peak_driven_rate = 0
         cf = cf_khz = thresh = thresh_db = None
-        bw10 = bw20 = bw30 = bw40 = [None, None]
-        continuous_bw = [None, None]
-        bw10_octave = bw20_octave = bw30_octave = bw40_octave = None
+        bw_idx = {lvl: [None, None] for lvl in BW_LEVELS}
+        bw_khz, bw_oct = bw_idx_to_units(bw_idx, freqs)
+        continuous_bw = continuous_bw_khz = [None, None]
         continuous_bw_octave = None
-        bw10_khz = bw20_khz = bw30_khz = bw40_khz = [None, None]
-        continuous_bw_khz = [None, None]
     elif final_file is not None:
         # Don't measure continuous for analysis pulled from final file
         continuous_bw = [None, None]
@@ -486,53 +485,22 @@ def densetc_bw_loop(idx, file, total, use_f32, n_sweeps, freqs, ints,
             cf = int(np.where(int(cf_khz*1000) == freqs.astype(int))[0][0])
             thresh = int(np.where(thresh_db == ints)[0][0])
             
-        if row["bw10a"].values == 0:
-            bw10 = [None, None]
-            bw10_khz = [None, None]
-            bw10_octave = None
-        else:
-            bw10a = afunc.snap(freqs/1000, row["bw10a"].values)
-            bw10b = afunc.snap(freqs/1000, row["bw10b"].values)
-            bw10 = [int(np.where(int(bw10a*1000) == freqs.astype(int))[0][0]),
-                    int(np.where(int(bw10b*1000) == freqs.astype(int))[0][0])]
-            bw10_khz = [bw10a, bw10b]
-            bw10_octave = row["bw10"].values[0]
-
-        if row["bw20a"].values == 0:
-            bw20 = [None, None]
-            bw20_khz = [None, None]
-            bw20_octave = None
-        else:
-            bw20a = afunc.snap(freqs/1000, row["bw20a"].values)
-            bw20b = afunc.snap(freqs/1000, row["bw20b"].values)
-            bw20 = [int(np.where(int(bw20a*1000) == freqs.astype(int))[0][0]),
-                    int(np.where(int(bw20b*1000) == freqs.astype(int))[0][0])]
-            bw20_khz = [bw20a, bw20b]
-            bw20_octave = row["bw20"].values[0]
-
-        if row["bw30a"].values == 0:
-            bw30 = [None, None]
-            bw30_khz = [None, None]
-            bw30_octave = None
-        else:
-            bw30a = afunc.snap(freqs/1000, row["bw30a"].values)
-            bw30b = afunc.snap(freqs/1000, row["bw30b"].values)
-            bw30 = [int(np.where(int(bw30a*1000) == freqs.astype(int))[0][0]),
-                    int(np.where(int(bw30b*1000) == freqs.astype(int))[0][0])]
-            bw30_khz = [bw30a, bw30b]
-            bw30_octave = row["bw30"].values[0]
-
-        if row["bw40a"].values == 0:
-            bw40 = [None, None]
-            bw40_khz = [None, None]
-            bw40_octave = None
-        else:
-            bw40a = afunc.snap(freqs/1000, row["bw40a"].values)
-            bw40b = afunc.snap(freqs/1000, row["bw40b"].values)
-            bw40 = [int(np.where(int(bw40a*1000) == freqs.astype(int))[0][0]),
-                    int(np.where(int(bw40b*1000) == freqs.astype(int))[0][0])]
-            bw40_khz = [bw40a, bw40b]
-            bw40_octave = row["bw40"].values[0]
+        bw_idx, bw_khz, bw_oct = {}, {}, {}
+        for lvl in BW_LEVELS:
+            a_raw = row[f"bw{lvl}a"].values
+            if a_raw == 0:
+                bw_idx[lvl] = [None, None]
+                bw_khz[lvl] = [None, None]
+                bw_oct[lvl] = None
+                continue
+            a = afunc.snap(freqs / 1000, a_raw)
+            b = afunc.snap(freqs / 1000, row[f"bw{lvl}b"].values)
+            bw_idx[lvl] = [
+                int(np.where(int(a * 1000) == freqs.astype(int))[0][0]),
+                int(np.where(int(b * 1000) == freqs.astype(int))[0][0]),
+            ]
+            bw_khz[lvl] = [a, b]
+            bw_oct[lvl] = row[f"bw{lvl}"].values[0]
         
     else:  # Normal analysis on responsive site
         try:  # Cont BW crashes program if TC doesn't return "good enough" data
@@ -545,35 +513,12 @@ def densetc_bw_loop(idx, file, total, use_f32, n_sweeps, freqs, ints,
                 driven_offset_ms=offset,
                 spont_onset_ms=400 - (offset - onset),
                 spont_offset_ms=400)
-            # TODO check this
             ttest_tc = afunc.ttest_driven_vs_spont_tc(*ttest_spike_counts)
-            # TODO gross, clean up
-            _, _, cf, thresh, bw10, bw20, bw30, bw40, continuous_bw, _ = afunc.ttest_analyze_tuning_curve(ttest_tc)
-
-            if bw10[0] is not None:
-                bw10_khz = (freqs[bw10] / 1000).tolist()
-                bw10_octave = afunc.get_bandwidth(*freqs[bw10]).tolist()
-            else:
-                bw10_khz = [None, None]
-                bw10_octave = None
-            if bw20[0] is not None:
-                bw20_khz = (freqs[bw20] / 1000).tolist()
-                bw20_octave = afunc.get_bandwidth(*freqs[bw20]).tolist()
-            else:
-                bw20_khz = [None, None]
-                bw20_octave = None
-            if bw30[0] is not None:
-                bw30_khz = (freqs[bw30] / 1000).tolist()
-                bw30_octave = afunc.get_bandwidth(*freqs[bw30]).tolist()
-            else:
-                bw30_khz = [None, None]
-                bw30_octave = None
-            if bw40[0] is not None:
-                bw40_khz = (freqs[bw40] / 1000).tolist()
-                bw40_octave = afunc.get_bandwidth(*freqs[bw40]).tolist()
-            else:
-                bw40_khz = [None, None]
-                bw40_octave = None
+            r = afunc.ttest_analyze_tuning_curve(ttest_tc)
+            cf, thresh = r.cf, r.thresh
+            bw_idx = r.bw_idx
+            bw_khz, bw_oct = bw_idx_to_units(bw_idx, freqs)
+            continuous_bw = r.continuous_bw
 
             continuous_bw_khz = [(freqs[bw] / 1000).tolist() for 
                                  bw in continuous_bw]
@@ -586,12 +531,10 @@ def densetc_bw_loop(idx, file, total, use_f32, n_sweeps, freqs, ints,
             # Still keeps any estimated onset/offset though.. hm.
             peak_driven_rate = 0
             cf = cf_khz = thresh = thresh_db = None
-            bw10 = bw20 = bw30 = bw40 = [None, None]
-            continuous_bw = [None, None]
-            bw10_octave = bw20_octave = bw30_octave = bw40_octave = None
+            bw_idx = {lvl: [None, None] for lvl in BW_LEVELS}
+            bw_khz, bw_oct = bw_idx_to_units(bw_idx, freqs)
+            continuous_bw = continuous_bw_khz = [None, None]
             continuous_bw_octave = None
-            bw10_khz = bw20_khz = bw30_khz = bw40_khz = [None, None]
-            continuous_bw_khz = [None, None]
 
     # Apparently sometimes nan's for latency probs?
     # Just in case, nan_to_num: nan's -> 0, and inf's -> large values
@@ -606,18 +549,6 @@ def densetc_bw_loop(idx, file, total, use_f32, n_sweeps, freqs, ints,
         "threshold_db": thresh_db, 
         "cf_idx": cf,
         "threshold_idx": thresh,
-        "bw10_khz": bw10_khz, 
-        "bw20_khz": bw20_khz,
-        "bw30_khz": bw30_khz,
-        "bw40_khz": bw40_khz,
-        "bw10_idx": bw10,
-        "bw20_idx": bw20, 
-        "bw30_idx": bw30,
-        "bw40_idx": bw40,
-        "bw10_octave": bw10_octave,
-        "bw20_octave": bw20_octave,
-        "bw30_octave": bw30_octave, 
-        "bw40_octave": bw40_octave,
         "continuous_bw_khz": continuous_bw_khz, 
         "continuous_bw_idx": continuous_bw,
         "continuous_bw_octave": continuous_bw_octave,
@@ -637,6 +568,10 @@ def densetc_bw_loop(idx, file, total, use_f32, n_sweeps, freqs, ints,
         "bb_sdf": latency_dict["sdf"].tolist(),
         "field_assignment": "",
     }
+    for lvl in BW_LEVELS:
+        analysis_dict[f"bw{lvl}_idx"] = bw_idx[lvl]
+        analysis_dict[f"bw{lvl}_khz"] = bw_khz[lvl]
+        analysis_dict[f"bw{lvl}_octave"] = bw_oct[lvl]
     return_dict = {"data_dict": bw_dict, 
                    "analysis_dict": analysis_dict, 
                    "penetration_number": bw_dict["penetration_number"]}

--- a/src/site_model.py
+++ b/src/site_model.py
@@ -223,7 +223,7 @@ class SiteModel:
         if self._contour_cache[0] == key:
             return self._contour_cache[1]
 
-        smooth = afunc.ttest_analyze_tuning_curve(self.ttest_tc(*key))[0]
+        smooth = afunc.ttest_analyze_tuning_curve(self.ttest_tc(*key)).tc_image
         smooth[smooth > 0] = 1
 
         self._contour_cache = (key, smooth)


### PR DESCRIPTION
Cleaning up the repeated logic of bw10/20/30/40 into simpler loops. Small util constants and a TCResult namedtuple introduced as a stopover until more complete refactor consolidates everything.

Also a one-off change to the `snap` util function, redefining it in terms of input->grid index; cleans up subsequent reverse-searches using returned snap values.