### PR TITLE
Finish implementing OCR suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 - [Setup](#setup)
   - [Anaconda (do this unless you know what you are doing without it)](#anaconda-do-this-unless-you-know-what-you-are-doing-without-it)
   - [Necessary software](#necessary-software)
-    - [Tesseract](#tesseract)
+    - [OCR resources](#ocr-resources)
     - [Special installs](#special-installs)
     - [Special note about Kivy](#special-note-about-kivy)
   - [(optional) Dadroit JSON viewer](#optional-dadroit-json-viewer)
@@ -12,9 +12,11 @@
   - [Analyze subject](#analyze-subject)
     - [Filetype](#filetype)
     - [Electrode penetration x/y data](#electrode-penetration-xy-data)
+    - [OCR sources and exports](#ocr-sources-and-exports)
     - [Voronoi tessellation](#voronoi-tessellation)
     - [Analysis](#analysis)
   - [Generate analysis from final file](#generate-analysis-from-final-file)
+  - [OCR template tools](#ocr-template-tools)
   - [Select fields GUI](#select-fields-gui)
   - [Final file generation](#final-file-generation)
   - [IC Final file generation](#ic-final-file-generation)
@@ -37,16 +39,15 @@ Download/install Anaconda https://www.anaconda.com/, then use the `conda-env.yml
 - `conda env create -f conda-env.yml -n <your-env-name>`
 
 ## Necessary software
-### Tesseract
-- Homepage: https://tesseract-ocr.github.io/tessdoc/Home.html
-- Windows installer: https://github.com/UB-Mannheim/tesseract/wiki
+### OCR resources
+Map-number OCR now uses the built-in `DigitOCR` template/font workflow. No Tesseract install or traineddata copy is required.
 
-Used for OCR of map images to create the beautiful voronoi plots with points and numbers all matched up.
+Out of the box, the program ships with a default OCR font at:
+- `resources/OCR-A.otf`
 
-Currently the path to the .exe **MUST** be given to python by the `map_analysis` program, and it is hardcoded to the default install location (which is highly recommended to leave as-is by tesseract Windows team anyway):
-- `"C:/Program Files/Tesseract-OCR"`
+If `resources/digit_templates.npz` exists, that template set is preferred over the default font. You can also browse to any other `.npz`, `.ttf`, or `.otf` file when prompted during analysis or template preview.
 
-After installing, you **MUST** copy `./resources/mapOCR.traineddata` from this repo to `"C:/Program Files/Tesseract-OCR/tessdata/"`. This is the training file that tells tesseract how to OCR our map numbers from associated image files. For the life of me I don't know why the non-specially-trained OCR engine struggles with what should be a simple job, but it does. This training file was a pain to create, but it works.
+If you want a project-specific OCR setup, use the `o` menu option in `map_analysis.py` to bootstrap a template set from your own number/mask images and save it wherever you want.
 
 ### Special installs
 #### kivy-garden
@@ -109,6 +110,18 @@ The program can load x/y coordinate data from images, "final files" (lab-specifi
 
 Demo analysis uses images -- select `i`, then use `demo/img/pts.png`, `demo/img/num.png`, and `demo/img/msk.png` for points, numbers, and mask, respectively.
 
+### OCR sources and exports
+If image-based coordinates are selected, the program next asks which OCR source to use for the map numbers.
+
+Default behavior:
+- If `resources/digit_templates.npz` exists, it is offered as the default OCR source.
+- Otherwise `resources/OCR-A.otf` is offered as the default OCR source.
+
+Alternative behavior:
+- If you answer `n` to the default prompt, you can browse to any saved OCR template set (`.npz`) or a font file (`.ttf` / `.otf`).
+
+After OCR finishes, the program shows a proof-sheet review of all recognized map numbers. You can optionally save the recognized coordinates to a `.csv` file (`number,x,y`) for record-keeping or reuse.
+
 ### Voronoi tessellation
 In auditory cortical maps, each point on the cortical surface is assumed to have the characteristics of the closest sampled penetration. A voronoi tessellation is generated from the map electrode x/y data. To prevent outer edges extending to infinity, an initial set of border points is automatically generated around the perimeter of the map (and their corresponding polygons ignored):
 ![Initial set of automatic border points around voronoi tessellation](resources/img/demo_prevor.png)
@@ -136,6 +149,21 @@ Speech and noiseburst auto-analyses were planned but never yet included, so only
 ## Generate analysis from final file
 Option specific to our lab for generating a subject analysis file for use with the "Select fields GUI" using a previous MATLAB format. Final file must be .xls file. Export `.mat` to `.xls` in MATLAB.
 - Currently you cannot add a new final-file analysis to an existing subject database, you have to make a new one.
+
+## OCR template tools
+Enter `o` at the main CLI menu to open the OCR template tools.
+
+Available actions:
+- `b` bootstraps a new OCR template set from a map `numbers` image plus its matching `mask` image.
+- `p` previews an OCR source before you use it. You can preview the default source or browse to another `.npz`, `.ttf`, or `.otf`.
+
+Bootstrap flow:
+- Choose whether to save to the default template path (`resources/digit_templates.npz`) or another `.npz` file.
+- Select a `numbers` image and its matching `mask` image.
+- Label each extracted digit crop interactively.
+- Save the resulting template set for later reuse in analysis.
+
+This is useful when the bundled `OCR-A.otf` works poorly for a given project's map images, or when you want to maintain multiple OCR sources for different projects.
 
 ## Select fields GUI
 GUI application to manually edit neurophysiological tuning curve analysis and select auditory cortical fields / responsive IC sites.

--- a/src/map_analysis.py
+++ b/src/map_analysis.py
@@ -100,24 +100,33 @@ def _launch_gui(db_path, analysis_id, is_ic):
 
 
 def _ocr_template_tools():
-    # TODO
-    print("Not yet implemented.")
-    return
+    def _bootstrap_templates():
+        subject_analysis.bootstrap_digit_templates()
+
+    def _preview_templates():
+        source_path = subject_analysis.prompt_digit_ocr_source()
+        if source_path is None:
+            cli.warn("Preview canceled before choosing an OCR source.")
+            return
+
+        cli.info(f"Previewing {source_path}:")
+        ocr = subject_analysis.load_digit_ocr(source_path)
+        ocr.print_summary()
+        ocr.preview_templates()
 
     while True:
         print(Fore.CYAN + Style.BRIGHT)
         print("\nOCR template tools:")
-        print(f" * [{Fore.WHITE}b{Fore.CYAN}]ootstrap new template set")
-        print(f" * [{Fore.WHITE}p{Fore.CYAN}]review template set")
-        print(f" * e[{Fore.WHITE}x{Fore.CYAN}]it OCR tools")
+        print(_style_menu_option("[b]ootstrap new template set"))
+        print(_style_menu_option("[p]review template set"))
+        print(_style_menu_option("e[x]it OCR tools"))
         print(Style.RESET_ALL)
 
-        # TODO finish implementing
         ch = input("> ").strip().lower()
         if ch == "b":
-            pass
+            _bootstrap_templates()
         elif ch == "p":
-            pass
+            _preview_templates()
         elif ch == "x":
             break
 
@@ -210,6 +219,12 @@ def _action_exit(state):
     state.running = False
 
 
+def _style_menu_option(label):
+    styled = (label.replace("[", f"[{Fore.WHITE}")
+              .replace("]", f"{Fore.CYAN}]"))
+    return f" * {styled}"
+
+
 # (label, handler) pairs. Label uses [k] to mark the highlighted key
 # letter; _print_menu styles it. Dict order is menu order.
 _ACTIONS = {
@@ -241,9 +256,7 @@ def _print_menu(state):
     print()
     print("Available actions:")
     for label, _ in _ACTIONS.values():
-        styled = (label.replace("[", f"[{Fore.WHITE}")
-                       .replace("]", f"{Fore.CYAN}]"))
-        print(f" * {styled}")
+        print(_style_menu_option(label))
     print(Style.RESET_ALL)
 
 

--- a/src/subject_analysis.py
+++ b/src/subject_analysis.py
@@ -16,9 +16,180 @@ import ray
 
 from digit_ocr import DigitOCR
 
-RESOURCES = Path("../resources")
+RESOURCES = Path(__file__).resolve().parent.parent / "resources"
 TEMPLATE_FILE = RESOURCES / "digit_templates.npz"
 FONT_FILE = RESOURCES / "OCR-A.otf"
+FONT_EXTENSIONS = (".ttf", ".otf")
+
+
+def default_digit_ocr_source():
+    if TEMPLATE_FILE.exists():
+        return TEMPLATE_FILE
+    if FONT_FILE.exists():
+        return FONT_FILE
+    return None
+
+
+def load_digit_ocr(source_path=None):
+    if source_path is None:
+        raise FileNotFoundError(
+            "No templates or font file found. Add a font .ttf/.otf file to "
+            f"{RESOURCES}, run a template OCR bootstrap from the main menu, "
+            "or choose a template (.npz) or font file (.ttf/.otf) manually."
+        )
+
+    source_path = Path(source_path)
+    suffix = source_path.suffix.lower()
+    if suffix == ".npz":
+        return DigitOCR.load(source_path)
+    elif suffix in FONT_EXTENSIONS:
+        return DigitOCR.from_font(source_path)
+    raise FileNotFoundError(
+        "Unsupported OCR source. Choose a .npz template set or a "
+        ".ttf/.otf font file."
+    )
+
+
+def extract_number_crops(numbers_image, mask_image, threshold=128):
+    if numbers_image is None or mask_image is None:
+        raise ValueError("Both numbers and mask images are required.")
+    if numbers_image.shape != mask_image.shape:
+        raise ValueError("Numbers and mask images must share the same shape.")
+
+    mask_binary = mask_image < threshold
+    mask_label = label(mask_binary)
+    mask_regions = regionprops(mask_label)
+    number_crops = [
+        numbers_image[min_row:max_row, min_col:max_col]
+        for min_row, min_col, max_row, max_col in
+        (region.bbox for region in mask_regions)
+    ]
+    return mask_regions, number_crops
+
+
+def _load_grayscale_image(title, prompt):
+    cli.info(prompt)
+    image_path = afunc.get_file(title=title, filetypes=[("PNG", ".png")])
+    if not image_path:
+        return None, None
+
+    image = cv2.imread(image_path, cv2.IMREAD_GRAYSCALE)
+    if image is None:
+        raise FileNotFoundError(f"Couldn't read image: {image_path}")
+    return image_path, image
+
+
+def load_number_mask_data():
+    numbers_path, numbers_image = _load_grayscale_image(
+        "Select Map Numbers image", "Select map NUMBERS image:"
+    )
+    if numbers_image is None:
+        return None
+
+    mask_path, mask_image = _load_grayscale_image(
+        "Select Map Mask image", "Select matching map MASK image:"
+    )
+    if mask_image is None:
+        return None
+
+    mask_regions, number_crops = extract_number_crops(numbers_image, mask_image)
+    return {
+        "numbers_path": numbers_path,
+        "mask_path": mask_path,
+        "numbers_image": numbers_image,
+        "mask_image": mask_image,
+        "mask_regions": mask_regions,
+        "number_crops": number_crops,
+    }
+
+
+def choose_digit_ocr_source():
+    picked = afunc.get_file(
+        title="Select OCR template or font file",
+        filetypes=[
+            ("OCR templates or fonts", ".npz .ttf .otf"),
+            ("NumPy template archive", ".npz"),
+            ("TrueType font", ".ttf"),
+            ("OpenType font", ".otf"),
+        ],
+    )
+    return Path(picked) if picked else None
+
+
+def prompt_digit_ocr_source():
+    default_source = default_digit_ocr_source()
+    if default_source is None or not cli.ask_yes_no(
+        f"Use default OCR source ({default_source}) [y/n]? > "
+    ):
+        return choose_digit_ocr_source()
+    return default_source
+
+
+def choose_template_save_path():
+    if cli.ask_yes_no(
+        f"Save templates to default path {TEMPLATE_FILE} [y/n]? > "
+    ):
+        return TEMPLATE_FILE
+
+    save_path = afunc.save_file(
+        title="Save digit template set",
+        defaultextension=".npz",
+        initialdir=str(TEMPLATE_FILE.parent),
+        initialfile=TEMPLATE_FILE.name,
+        filetypes=[("NumPy template archive", ".npz")],
+    )
+    return Path(save_path) if save_path else None
+
+
+def _normalize_output_path(path, extension):
+    path = Path(path)
+    ext = extension.lower()
+
+    while path.name.lower().endswith(ext + ext):
+        path = path.with_name(path.name[:-len(ext)])
+
+    if path.suffix.lower() != ext:
+        path = path.with_suffix(extension)
+    return path
+
+
+def choose_csv_save_path(initial_dir, initial_name):
+    save_path = afunc.save_file(
+        title="Save OCR coordinates CSV",
+        defaultextension=".csv",
+        initialdir=str(initial_dir),
+        initialfile=initial_name,
+        filetypes=[("CSV", ".csv")],
+    )
+    if not save_path:
+        return None
+
+    save_path = _normalize_output_path(save_path, ".csv")
+    if save_path.exists() and not cli.ask_yes_no(
+        f"Overwrite existing CSV at {save_path} [y/n]? > "
+    ):
+        return None
+    return save_path
+
+
+def bootstrap_digit_templates():
+    template_path = choose_template_save_path()
+    if template_path is None:
+        cli.warn("Template bootstrap canceled before choosing a save path.")
+        return
+
+    number_data = load_number_mask_data()
+    crops = number_data["number_crops"]
+
+    if template_path.exists() and not cli.ask_yes_no(
+        f"Overwrite existing template set at {template_path} [y/n]? > "
+    ):
+        return
+
+    template_path.parent.mkdir(parents=True, exist_ok=True)
+    ocr = DigitOCR.bootstrap(crops)
+    ocr.save(template_path)
+    cli.success(f"Saved OCR template set to {template_path}")
 
 
 def _ic_depth(ic_points_df, penetration_number):
@@ -143,37 +314,25 @@ def run_program(config_dict, version, final_file=None, return_sdf=True):
     map_height = 1
     map_points_df = pd.DataFrame([{"number": None}])
     if use_images:
-        if TEMPLATE_FILE.exists():
-            OCR = DigitOCR.load(TEMPLATE_FILE)
-        elif FONT_FILE.exists():
-            OCR = DigitOCR.from_font(FONT_FILE)
-        else:
-            raise FileNotFoundError(
-                "No templates or font file found. Add a font .ttf/.otf file "
-                "to or run the digit template bootstrap option."
-            )
+        source_path = prompt_digit_ocr_source()
+        OCR = load_digit_ocr(source_path)
 
-        cli.info("Select map POINTS image:")
-        points_im_filename = afunc.get_file(title="Select Map Points image",
-                                            filetypes=[("PNG", ".png")])
-        points_image = cv2.imread(points_im_filename, cv2.IMREAD_GRAYSCALE)
+        _, points_image = _load_grayscale_image(
+            "Select Map Points image", "Select map POINTS image:"
+        )
+        if points_image is None:
+            raise FileNotFoundError("No map points image selected.")
         points_binary = points_image < 128
         points_label = label(points_binary)
         points_regions = regionprops(points_label)
 
-        cli.info("Select map NUMBERS image:")
-        numbers_im_filename = afunc.get_file(title="Select Map Numbers image",
-                                             filetypes=[("PNG", ".png")])
-        numbers_image = cv2.imread(numbers_im_filename, cv2.IMREAD_GRAYSCALE)
+        number_data = load_number_mask_data()
+        if number_data is None:
+            raise FileNotFoundError("Map numbers/mask image selection was canceled.")
+        numbers_image = number_data["numbers_image"]
         norm_row_max, norm_col_max = numbers_image.shape
-
-        cli.info("Select map MASK image:")
-        mask_im_filename = afunc.get_file(title="Select Map Mask image",
-                                          filetypes=[("PNG", ".png")])
-        mask_image = cv2.imread(mask_im_filename, cv2.IMREAD_GRAYSCALE)
-        mask_binary = mask_image < 128
-        mask_label = label(mask_binary)
-        mask_regions = regionprops(mask_label)
+        mask_regions = number_data["mask_regions"]
+        number_crops = number_data["number_crops"]
 
         if len(mask_regions) != len(points_regions):
             raise AssertionError(
@@ -184,9 +343,7 @@ def run_program(config_dict, version, final_file=None, return_sdf=True):
         map_height, map_width = points_image.shape
         points_centroids = np.array([r.centroid for r in points_regions])
         results = []
-        for mask_props in mask_regions:
-            bbox = mask_props.bbox
-            crop = numbers_image[bbox[0]:bbox[2], bbox[1]:bbox[3]]
+        for mask_props, crop in zip(mask_regions, number_crops):
             ocr_result = OCR.recognize(crop)
 
             distances = np.linalg.norm(
@@ -197,6 +354,14 @@ def run_program(config_dict, version, final_file=None, return_sdf=True):
             results.append(ocr_result)
 
         OCR.review_results(results)
+        if cli.ask_yes_no("Save coordinates to .csv file [y/n]? > "):
+            csv_path = choose_csv_save_path(
+                save_dir_path, f"{subject_name}_coords.csv"
+            )
+            if csv_path is None:
+                cli.warn("CSV export canceled.")
+            else:
+                OCR.export_results_csv(results, csv_path)
         map_points_df = pd.DataFrame(
             [{"number": r.number, "x": r.metadata["x"], "y": r.metadata["y"]}
              for r in results]


### PR DESCRIPTION
Finishes where #31 left off
- adds bootstrapping templates and preview to the CLI menu
- utilizes a more robust set of options in `subject_analysis.py` so users can choose default templates or select new ones
- also extracted some of the duplicated logic around selecting and using images
- updated readme to document OCR tools

Resolves #43 