### PR TITLE
Move project config out of `analysis_metadata`

### DIFF
--- a/src/Field_Selection_GUI.py
+++ b/src/Field_Selection_GUI.py
@@ -24,7 +24,7 @@ from matplotlib.collections import LineCollection
 from matplotlib.figure import Figure
 from matplotlib.path import Path as MplPath
 import cmocean
-from db_adapter import JSONStore
+from db_adapter import JSONStore, get_project_config
 from field_definitions import (
     FIELD_FILL_COLORS,
     FIELD_LINE_COLORS,
@@ -955,11 +955,8 @@ class FieldSelectionGUI(BoxLayout):
                     self.subject_database.densetc_analysis
 
             # --- Project configuration -------------------------------
-            # Expect exactly one analysis metadata doc to carry a
-            # configuration (the auto-analysis run).
-            self.project_configuration = \
-                self.analysis_metadata_collection.find_one(
-                    {"configuration": {"$exists": True}})["configuration"]
+            self.project_configuration = get_project_config(
+                self.subject_database)
 
             # --- Sites, data, analysis -------------------------------
             if is_ic:

--- a/src/db_adapter.py
+++ b/src/db_adapter.py
@@ -13,8 +13,9 @@ Supported:
     coll.find({})                                      # all docs
     coll.find({"analysis_id": x, "number": 3})         # equality filter(s), AND-ed
     coll.find_one({...})                               # first match or None
-    coll.find_one({"configuration": {"$exists": True}})
+    coll.get_only()                                    # exactly one document
     coll.update_one({"_id": x}, {"$set": {...}})
+    get_project_config(db)                             # read-through migration
 
 Not supported: delete, $gt/$lt/$in/$ne, nested paths, projections, sort.
 Add them if something new needs them.
@@ -59,6 +60,31 @@ class JSONStore:
 
     def close(self):
         self._db.close()
+
+
+def get_project_config(db):
+    """
+    Return the project-level stimulus configuration for a subject DB.
+
+    Newer databases store it on the single metadata document.
+    Older databases stored it on the frozen auto-analysis metadata doc;
+    when found there, write it forward so future reads use the new home.
+    """
+    meta = db.metadata.get_only()
+    if "project_configuration" in meta:
+        return meta["project_configuration"]
+
+    legacy = db.analysis_metadata.find_one({"configuration": {"$exists": True}})
+    if legacy is None:
+        raise ValueError(
+            "No project configuration found in db.metadata or legacy "
+            "analysis_metadata."
+        )
+
+    cfg = legacy["configuration"]
+    db.metadata.update_one({"_id": meta["_id"]},
+                           {"$set": {"project_configuration": cfg}})
+    return cfg
 
 
 class Collection:

--- a/src/subject_analysis.py
+++ b/src/subject_analysis.py
@@ -347,8 +347,11 @@ def run_program(config_dict, version, final_file=None, return_sdf=True):
     db_sites = db.sites
     db_analysis_metadata = db.analysis_metadata
 
-    meta_id = db_metadata.insert_one({"program_version": analysis_version,
-                                      "program_run_date": today}).inserted_id
+    meta_id = db_metadata.insert_one({
+        "program_version": analysis_version,
+        "program_run_date": today,
+        "project_configuration": config_dict,
+    }).inserted_id
     if final_file is not None:
         analysis_comment = "Tuning curve analysis generated from a final file"
     else:
@@ -357,7 +360,6 @@ def run_program(config_dict, version, final_file=None, return_sdf=True):
         "name": analysis_version,
         "start_date": today,
         "last_modified": today,
-        "configuration": config_dict,
         "frozen": True,
         "comments": analysis_comment,
     }).inserted_id


### PR DESCRIPTION
I don't know why I put it there originally; probably an idea that each analysis would carry project level information so they would be self-contained. Regardless, retrospectively revisiting and refactoring reveals it should probably live in the `metadata` top-level collection.

This PR introduces `get_project_config` helper in `db_adapter`, which will fetch project configs from either legacy or now the new storage schema (and writes to the new schema when legacy is encountered so all future gets are correct going forward). `subject_analysis` now writes to `metadata` going forward, and the GUI uses the `get_project_config` helper instead of looking it up with the previous hack solution.