### PR TITLE
Generalize `create_new_densetc_analysis` into `db_adapter`

### DIFF
--- a/src/analysis_admin.py
+++ b/src/analysis_admin.py
@@ -119,37 +119,12 @@ def create_new_densetc_analysis(template_id, new_metadata,
                                 densetc_analysis_collection, 
                                 bonus_analysis_collection):
     """
-    Create a new analysis for a subject.
-    Adds metadata and duplicates entries from an existing analysis.
-    
-    Expects a dictionary of new analysis metadata and the analysis metadata and
-      densetc_analysis tinydb "mongo" collections to update. Duplicates existing 
-      analysis and replaces id with new analysis id.
-      
-    Returns new analysis_metadata _id.
+    Create a new analysis by inserting metadata and cloning the matching
+    analysis docs from the main and bonus collections onto the new ID.
     """
-    # TODO allow blank analysis, with just empty fields
     analysis_id = analysis_metadata_collection.insert_one(
         new_metadata).inserted_id
-    # NEW: Must wrap dict(site), stupid tinydb change. Won't insert otherwise.
-    #  https://github.com/msiemens/tinydb/issues/354
-    template_analysis = [
-        dict(site) for site in 
-        densetc_analysis_collection.find({"analysis_id": template_id})]
-    # If there are no IC/cortical sites, an empty collection is created in the 
-    #   database, harming no one
-    # If there are, they are duplicated like expected and can be accessed from
-    #   the same analysis ID
-    bonus_analysis = [
-        dict(site) for site in 
-        bonus_analysis_collection.find({"analysis_id": template_id})]
-    for site in template_analysis:
-        site["analysis_id"] = analysis_id
-        del site["_id"]
-    for site in bonus_analysis:
-        site["analysis_id"] = analysis_id
-        del site["_id"]
-    densetc_analysis_collection.insert_many(template_analysis)
-    bonus_analysis_collection.insert_many(bonus_analysis)
-    
+    densetc_analysis_collection.clone_by("analysis_id", template_id,
+                                         analysis_id)
+    bonus_analysis_collection.clone_by("analysis_id", template_id, analysis_id)
     return analysis_id

--- a/src/db_adapter.py
+++ b/src/db_adapter.py
@@ -14,6 +14,7 @@ Supported:
     coll.find({"analysis_id": x, "number": 3})         # equality filter(s), AND-ed
     coll.find_one({...})                               # first match or None
     coll.get_only()                                    # exactly one document
+    coll.clone_by("analysis_id", old_id, new_id)       # duplicate matching docs
     coll.update_one({"_id": x}, {"$set": {...}})
     get_project_config(db)                             # read-through migration
 
@@ -106,6 +107,19 @@ class Collection:
         if len(docs) != 1:
             raise ValueError(f"Expected exactly 1 document, found {len(docs)}")
         return docs[0]
+
+    def clone_by(self, field, old_value, new_value):
+        """
+        Duplicate every document where `field == old_value`, rewriting that
+        field to `new_value` and dropping `_id` so fresh IDs are assigned.
+        """
+        clones = []
+        for doc in self.find({field: old_value}):
+            clone = dict(doc)
+            clone[field] = new_value
+            clone.pop("_id", None)
+            clones.append(clone)
+        return self.insert_many(clones)
     
     def insert_one(self, document):
         if not isinstance(document, dict):


### PR DESCRIPTION
It's not densetc specific, it just clones every doc matching `{field: old_id}`, rewrites `field` to `new_id`, strips `_id`, and re-inserts. Move to `db_adapter.py` as `Collection.clone_by(field, old_value, new_value)`.

`create_new_densetc_analysis` becomes a wrapper that inserts the metadata doc and calls `clone_by` on both collections.