### PR TITLE
Split run program into independent parts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 __pycache__
 *.log
 .vscode/
+*.DS_Store
 
 # Python bytecode / caches
 *.py[cod]

--- a/noxfile.py
+++ b/noxfile.py
@@ -19,6 +19,13 @@ def _run_smoke(session: nox.Session) -> None:
     session.run("python", str(Path("scripts") / "smoke_imports.py"))
 
 
+@nox.session(name="tests", python=SUPPORTED_PYTHONS)
+def tests(session: nox.Session) -> None:
+    session.install("-e", ".")
+    session.install("pytest")
+    session.run("pytest")
+
+
 @nox.session(name="smoke", python=SUPPORTED_PYTHONS)
 def smoke(session: nox.Session) -> None:
     _run_smoke(session)

--- a/src/bayesian_bins.py
+++ b/src/bayesian_bins.py
@@ -1,5 +1,10 @@
+import os
 from llvmlite import binding
-binding.set_option('SVML', '-vector-library=SVML')
+
+# SVML is not available in all environments (notably Apple Silicon worker
+# processes here). Keep it opt-in so JIT compilation stays portable.
+if os.environ.get("ADS_ENABLE_SVML") == "1":
+    binding.set_option('SVML', '-vector-library=SVML')
 
 import numpy as np
 from scipy.optimize import minimize_scalar

--- a/src/brainware.py
+++ b/src/brainware.py
@@ -93,6 +93,30 @@ def adjust_numbers(number):
     map_number = 4 * (penetration_number - 1) + electrode_number
     return map_number
 
+
+def _segment_group_spikes(blk, seg_idx):
+    """
+    Fallback for `.src` files under newer neo versions where per-segment
+    spiketrains are omitted and the sweep-aligned trains only live on the
+    Block groups. Match the old `seg.spiketrains[1]` intent by preferring the
+    first non-"UnassignedSpikes" group.
+
+    This keeps compatibility across neo layouts:
+      * older layouts exposed sweep spikes on `seg.spiketrains`
+      * neo 0.14.4 exposes the same sweep-aligned spikes on `blk.groups`
+    """
+    spike_idx = seg_idx - 1  # seg 0 is the comments segment
+    if spike_idx < 0:
+        return None
+
+    for group in getattr(blk, "groups", []):
+        if getattr(group, "name", None) == "UnassignedSpikes":
+            continue
+        spiketrains = getattr(group, "spiketrains", [])
+        if spike_idx < len(spiketrains):
+            return spiketrains[spike_idx].times.magnitude.tolist()
+    return None
+
 def get_spike_dict(blk, use_f32=False, dataset=None):
     """
     Takes a block (neo-processed brainware file) and a 'dataset' for a 
@@ -134,7 +158,7 @@ def get_spike_dict(blk, use_f32=False, dataset=None):
     params = known_datasets[dataset]
     
     spike_dict = defaultdict(list)
-    for seg in blk.segments:
+    for seg_idx, seg in enumerate(blk.segments):
         try:
             if use_f32:
                 key = tuple(int(seg.annotations[p]) for p in params["f32"])
@@ -144,11 +168,33 @@ def get_spike_dict(blk, use_f32=False, dataset=None):
                 idx = 1
             # Calling tolist() removes neo-added Quantities metadata unit (ms)
             # It does not serialize during data storage
-            spikes = seg.spiketrains[idx].times.magnitude.tolist()
+            if len(seg.spiketrains) <= idx:
+                fallback_spikes = _segment_group_spikes(blk, seg_idx)
+                if fallback_spikes is not None:
+                    spikes = fallback_spikes
+                elif len(seg.spiketrains) == 0:
+                    # Recent neo versions can omit empty per-segment spike
+                    # trains entirely for no-spike sweeps. Keep the sweep as []
+                    # instead of crashing so non-responsive sites remain
+                    # analyzable.
+                    spikes = []
+                else:
+                    raise IndexError
+            else:
+                spikes = seg.spiketrains[idx].times.magnitude.tolist()
             spike_dict[key].append(spikes)
         except KeyError:
             # Skip any segment that is empty or metadata
             continue
+        except IndexError as e:
+            raise IndexError(
+                "Segment spiketrain index out of range while parsing "
+                f"{getattr(blk, 'file_origin', '<unknown file>')!r} "
+                f"for dataset={dataset!r}, use_f32={use_f32}. "
+                f"segment_index={seg_idx}, requested_spiketrain_index={idx}, "
+                f"available_spiketrains={len(seg.spiketrains)}, "
+                f"annotation_keys={sorted(seg.annotations.keys())}"
+            ) from e
         
     return spike_dict
 

--- a/src/dialogs.py
+++ b/src/dialogs.py
@@ -13,6 +13,7 @@ even if the dialog raises.
 """
 import time
 from contextlib import contextmanager
+from pathlib import Path
 
 import tkinter as tk
 from tkinter import filedialog, simpledialog, messagebox, TclError
@@ -23,6 +24,8 @@ __all__ = [
 ]
 
 # -- internals -------------------------------------------------------------
+
+_LAST_DIALOG_DIR = Path.cwd()
 
 @contextmanager
 def _hidden_root():
@@ -37,6 +40,22 @@ def _hidden_root():
         except Exception:
             pass
 
+
+def _dialog_kwargs(kwargs):
+    dialog_kwargs = dict(kwargs)
+    dialog_kwargs.setdefault("initialdir", str(_LAST_DIALOG_DIR))
+    return dialog_kwargs
+
+
+def _remember_dialog_path(path, *, is_folder=False):
+    global _LAST_DIALOG_DIR
+
+    if not path:
+        return
+
+    picked = Path(path)
+    _LAST_DIALOG_DIR = picked if is_folder else picked.parent
+
 # -- file / folder primitives ---------------------------------------------
 
 def get_folder(**kwargs):
@@ -46,18 +65,23 @@ def get_folder(**kwargs):
     paths by string concat; TODO pathlib follow-up.)
     """
     with _hidden_root():
-        folder = filedialog.askdirectory(**kwargs)
+        folder = filedialog.askdirectory(**_dialog_kwargs(kwargs))
+    _remember_dialog_path(folder, is_folder=True)
     return (folder + "/") if folder else ""
 
 def get_file(**kwargs):
     """File-open picker. Returns path string, or empty string on cancel."""
     with _hidden_root():
-        return filedialog.askopenfilename(**kwargs)
+        path = filedialog.askopenfilename(**_dialog_kwargs(kwargs))
+    _remember_dialog_path(path)
+    return path
 
 def save_file(**kwargs):
     """File-save picker. Returns path string, or empty string on cancel."""
     with _hidden_root():
-        return filedialog.asksaveasfilename(**kwargs)
+        path = filedialog.asksaveasfilename(**_dialog_kwargs(kwargs))
+    _remember_dialog_path(path)
+    return path
 
 # -- simple prompt primitives ---------------------------------------------
 

--- a/src/map_analysis.py
+++ b/src/map_analysis.py
@@ -193,8 +193,20 @@ def _action_generate_from_final(state):
                     "onset","offset","x","y","field","number",]
         map_df = pd.read_excel(file, header=None, usecols=usecols,
                                names=colnames, engine="openpyxl")
-        subject_analysis.run_program(state.config_dict, state.version,
-                                     final_file=map_df, return_sdf=return_sdf)
+        run_ctx = subject_analysis.prepare_run_context(
+            state.config_dict,
+            state.version,
+            final_file_df=map_df,
+            return_sdf=return_sdf,
+        )
+        if run_ctx is None:
+            return
+        try:
+            completed = subject_analysis.run_brainware_analysis(run_ctx)
+            if completed:
+                cli.banner("\nIt's over! :)\n\n")
+        finally:
+            run_ctx.db.close()
     except Exception as e:
         cli.fail(e, f"Final-file generation crashed: {e}\n"
                     "Traceback in check_after_crash.log.")

--- a/src/stim_types/base.py
+++ b/src/stim_types/base.py
@@ -85,7 +85,7 @@ class StimulusType(ABC):
             self.store_config(config_dict, df)
             return
 
-    def worker_kwargs(self, config_dict, analysis_id=None, final_file=None,
+    def worker_kwargs(self, config_dict, analysis_id=None, final_file_df=None,
                       return_sdf=True):
         return {}
 

--- a/src/stim_types/densetc.py
+++ b/src/stim_types/densetc.py
@@ -43,17 +43,17 @@ class DenseTCStimulus(StimulusType):
             df["intensity"].values).tolist()
         config_dict["densetc_num_tones"] = len(df)
 
-    def worker_kwargs(self, config_dict, analysis_id=None, final_file=None,
+    def worker_kwargs(self, config_dict, analysis_id=None, final_file_df=None,
                       return_sdf=True):
         return {
             "cfg": StimConfig.from_project_config(config_dict),
             "analysis_id": analysis_id,
-            "final_file": final_file,
+            "final_file_df": final_file_df,
             "return_sdf": return_sdf,
         }
 
     def analyze_file(self, idx, file, total, use_f32, ic_pens=(), cfg=None,
-                     analysis_id=None, final_file=None, return_sdf=True,
+                     analysis_id=None, final_file_df=None, return_sdf=True,
                      **kwargs):
         result = _densetc_bw_loop(
             idx=idx,
@@ -62,7 +62,7 @@ class DenseTCStimulus(StimulusType):
             use_f32=use_f32,
             cfg=cfg,
             ic_pens=ic_pens,
-            final_file=final_file,
+            final_file_df=final_file_df,
             return_sdf=return_sdf,
         )
         result["docs"]["analysis"]["analysis_id"] = analysis_id
@@ -70,7 +70,7 @@ class DenseTCStimulus(StimulusType):
 
 
 def _densetc_bw_loop(idx, file, total, use_f32, cfg, ic_pens=(),
-                     final_file=None, return_sdf=True):
+                     final_file_df=None, return_sdf=True):
     freqs = np.asarray(cfg.frequencies_hz)
     ints = np.asarray(cfg.intensities_db)
     n_sweeps = cfg.num_tones
@@ -100,8 +100,8 @@ def _densetc_bw_loop(idx, file, total, use_f32, cfg, ic_pens=(),
     }
     if return_sdf:
         latency_dict = get_densetc_bb_lats(psth, n_sweeps, spont)
-    elif final_file is not None:
-        row = final_file[final_file["number"] == map_number]
+    elif final_file_df is not None:
+        row = final_file_df[final_file_df["number"] == map_number]
         onset = int(row["onset"].values)
         if not onset:
             onset, peak, offset = 50, None, 300
@@ -128,8 +128,8 @@ def _densetc_bw_loop(idx, file, total, use_f32, cfg, ic_pens=(),
     if latency_dict["peak"] is None:
         peak_driven_rate = 0
 
-    elif final_file is not None:
-        row = final_file[final_file["number"] == map_number]
+    elif final_file_df is not None:
+        row = final_file_df[final_file_df["number"] == map_number]
         if row["cf"].values != 0:
             cf = afunc.snap_idx(freqs / 1000, row["cf"].values)
             cf_khz = freqs[cf] / 1000

--- a/src/subject_analysis.py
+++ b/src/subject_analysis.py
@@ -312,6 +312,28 @@ def _gather_brainware_files(dir_path, enabled_stims, use_f32, nums, ic_pens,
     return bw_files
 
 
+@ray.remote
+def _analyze_stimulus_file(stim, idx, file, total, use_f32, ic_pens,
+                           worker_kwargs):
+    try:
+        return stim.analyze_file(
+            idx=idx,
+            file=file,
+            total=total,
+            use_f32=use_f32,
+            ic_pens=ic_pens,
+            **worker_kwargs,
+        )
+    except Exception as e:
+        file_name = getattr(file, "_filename", None)
+        if file_name is None:
+            file_name = getattr(file, "filename", "<unknown file>")
+        raise RuntimeError(
+            f"{stim.key} analysis failed for file {file_name!r} at worker "
+            f"index {idx} of {total}"
+        ) from e
+
+
 def _prompt_ic_map_options(config_dict):
     ic_bool = False
     ic_only = False
@@ -590,6 +612,15 @@ def _analysis_numbers(run_ctx, map_data):
 
 
 def run_brainware_analysis(run_ctx, map_data=None):
+    config_dict = run_ctx.config_dict
+    use_f32 = run_ctx.use_f32
+    analysis_id = run_ctx.analysis_id
+    final_file_df = run_ctx.final_file_df
+    return_sdf = run_ctx.return_sdf
+    ic_bool = run_ctx.ic_bool
+    ic_points_df = run_ctx.ic_points_df
+    db = run_ctx.db
+
     cli.info(
         "Select dir containing all Brainware files for subject"
         "(subfolders will be skipped):"
@@ -600,11 +631,11 @@ def run_brainware_analysis(run_ctx, map_data=None):
         return False
 
     nums = _analysis_numbers(run_ctx, map_data)
-    ic_pens = run_ctx.ic_points_df.number.values if run_ctx.ic_bool else []
-    enabled_stims = enabled_stim_types(run_ctx.config_dict)
+    ic_pens = ic_points_df.number.values if ic_bool else []
+    enabled_stims = enabled_stim_types(config_dict)
     bw_files = _gather_brainware_files(dir_path, enabled_stims,
-                                       run_ctx.use_f32, nums, ic_pens,
-                                       run_ctx.config_dict)
+                                       use_f32, nums, ic_pens,
+                                       config_dict)
 
     for stim in enabled_stims:
         files = bw_files.get(stim.key)
@@ -613,27 +644,19 @@ def run_brainware_analysis(run_ctx, map_data=None):
 
         total = len(files)
         worker_kwargs = stim.worker_kwargs(
-            run_ctx.config_dict,
-            analysis_id=run_ctx.analysis_id,
-            final_file_df=run_ctx.final_file_df,
-            return_sdf=run_ctx.return_sdf,
+            config_dict,
+            analysis_id=analysis_id,
+            final_file_df=final_file_df,
+            return_sdf=return_sdf,
         )
-
-        @ray.remote
-        def worker(idx, file):
-            return stim.analyze_file(
-                idx=idx,
-                file=file,
-                total=total,
-                use_f32=run_ctx.use_f32,
-                ic_pens=ic_pens,
-                **worker_kwargs,
+        results = ray.get([
+            _analyze_stimulus_file.remote(
+                stim, i, f, total, use_f32, ic_pens, worker_kwargs
             )
-
-        results = ray.get([worker.remote(i, f) for i, f in enumerate(files)])
+            for i, f in enumerate(files)
+        ])
         cli.success(f"\nSaving {stim.label} data...")
-        _route_and_insert(results, stim, run_ctx.db, run_ctx.ic_bool,
-                          ic_pens, run_ctx.ic_points_df)
+        _route_and_insert(results, stim, db, ic_bool, ic_pens, ic_points_df)
 
     return True
 

--- a/src/subject_analysis.py
+++ b/src/subject_analysis.py
@@ -2,6 +2,7 @@ import cv2
 import numpy as np
 import os
 from pathlib import Path
+from dataclasses import dataclass
 import pandas as pd
 from skimage.measure import label, regionprops
 import datetime
@@ -20,6 +21,36 @@ RESOURCES = Path(__file__).resolve().parent.parent / "resources"
 TEMPLATE_FILE = RESOURCES / "digit_templates.npz"
 FONT_FILE = RESOURCES / "OCR-A.otf"
 FONT_EXTENSIONS = (".ttf", ".otf")
+
+
+@dataclass(slots=True)
+class RunContext:
+    config_dict: dict
+    version: str
+    analysis_version: str
+    subject_name: str
+    save_dir_path: Path
+    db_path: Path
+    db: JSONStore
+    meta_id: str
+    analysis_id: str
+    use_f32: bool
+    ic_bool: bool
+    ic_only: bool
+    ic_points_df: pd.DataFrame
+    final_file_df: pd.DataFrame | None
+    return_sdf: bool
+
+
+@dataclass(slots=True)
+class MapData:
+    map_points_df: pd.DataFrame
+    map_width: int = 1
+    map_height: int = 1
+
+
+def _empty_number_df():
+    return pd.DataFrame([{"number": None}])
 
 
 def default_digit_ocr_source():
@@ -267,7 +298,7 @@ def _gather_brainware_files(dir_path, enabled_stims, use_f32, nums, ic_pens,
     for stim in enabled_stims:
         pattern = stim.file_prefix(config_dict)
         files = [
-            bw_io(filename=dir_path + entry.name)
+            bw_io(filename=entry.path)
             for entry in os.scandir(dir_path)
             if entry.name.endswith(ext)
             and entry.name.startswith(pattern)
@@ -281,25 +312,59 @@ def _gather_brainware_files(dir_path, enabled_stims, use_f32, nums, ic_pens,
     return bw_files
 
 
-def run_program(config_dict, version, final_file=None, return_sdf=True):
+def _prompt_ic_map_options(config_dict):
+    ic_bool = False
+    ic_only = False
+    ic_points_df = _empty_number_df()
+
+    if not config_dict["do_IC"]:
+        return ic_bool, ic_only, ic_points_df
+
+    if not cli.ask_yes_no("Does this subject have IC data [y/n]? > "):
+        return ic_bool, ic_only, ic_points_df
+
+    ic_bool = True
+    cli.info(
+        "Select .csv file listing IC map Penetration numbers with "
+        "corresponding depths (Number,Depth, no headers): "
+    )
+    ic_csv = afunc.get_file(title="IC Num,Depth .csv",
+                            filetypes=[("CSV", ".csv")])
+    if not ic_csv:
+        cli.warn("Analysis canceled before choosing an IC depth file.")
+        return None
+
+    ic_points_df = pd.read_csv(ic_csv, header=None,
+                               names=["number", "depth"])
+    ic_points_df = ic_points_df.sort_values("number").reset_index(drop=True)
+
+    if cli.ask_yes_no("Is this an IC only map [y/n]? > "):
+        ic_only = True
+
+    return ic_bool, ic_only, ic_points_df
+
+
+def prepare_run_context(config_dict, version, final_file_df=None,
+                        return_sdf=True):
     analysis_version = f"map_auto_analysis v{version}"
     today = str(datetime.datetime.now())
     subject_name = input("What is the subject's name? > ").strip()
     if not subject_name:
         cli.warn("Analysis canceled because the subject name was blank.")
-        return False
+        return None
 
     cli.info("Select folder to save to: ")
     save_dir_path = afunc.get_folder(title="Folder to save to")
     if not save_dir_path:
         cli.warn("Analysis canceled before choosing a save folder.")
-        return False
+        return None
+    save_dir_path = Path(save_dir_path)
 
     db_path, overwrite_existing = resolve_subject_db_path(save_dir_path,
                                                           subject_name)
     if db_path is None:
         cli.warn("Analysis canceled before writing a subject database.")
-        return False
+        return None
 
     use_f32 = False
     file_type = cli.ask_choice("Using .[s]rc or .[f]32 file type? > ",
@@ -307,36 +372,10 @@ def run_program(config_dict, version, final_file=None, return_sdf=True):
     if file_type == "f":
         use_f32 = True
 
-    ic_bool = False
-    ic_only = False
-    use_images = False
-    image_or_point_list = None
-    ic_points_df = pd.DataFrame([{"number": None}])
-    if config_dict["do_IC"]:
-        if cli.ask_yes_no("Does this subject have IC data [y/n]? > "):
-            ic_bool = True
-            cli.info(
-                "Select .csv file listing IC map Penetration numbers with "
-                "corresponding depths (Number,Depth, no headers): "
-            )
-            ic_csv = afunc.get_file(title="IC Num,Depth .csv",
-                                    filetypes=[("CSV", ".csv")])
-            ic_points_df = pd.read_csv(ic_csv, header=None,
-                                       names=["number", "depth"])
-            ic_points_df = ic_points_df.sort_values("number")
-            ic_points_df.reset_index(inplace=True, drop=True)
-
-            if cli.ask_yes_no("Is this an IC only map [y/n]? > "):
-                ic_only = True
-
-    image_or_point_list = ""
-    if (not ic_only) and (final_file is None):
-        image_or_point_list = cli.ask_choice(
-            "Using [i]mages, [f]inal file, or .[c]sv for map point data? > ",
-            ("i", "f", "c")
-        )
-        if image_or_point_list == "i":
-            use_images = True
+    ic_options = _prompt_ic_map_options(config_dict)
+    if ic_options is None:
+        return None
+    ic_bool, ic_only, ic_points_df = ic_options
 
     if overwrite_existing:
         db_path.unlink()
@@ -344,7 +383,6 @@ def run_program(config_dict, version, final_file=None, return_sdf=True):
 
     db = JSONStore(db_path)
     db_metadata = db.metadata
-    db_sites = db.sites
     db_analysis_metadata = db.analysis_metadata
 
     meta_id = db_metadata.insert_one({
@@ -352,7 +390,7 @@ def run_program(config_dict, version, final_file=None, return_sdf=True):
         "program_run_date": today,
         "project_configuration": config_dict,
     }).inserted_id
-    if final_file is not None:
+    if final_file_df is not None:
         analysis_comment = "Tuning curve analysis generated from a final file"
     else:
         analysis_comment = "Auto tuning curve analysis and data pre-processing"
@@ -364,118 +402,209 @@ def run_program(config_dict, version, final_file=None, return_sdf=True):
         "comments": analysis_comment,
     }).inserted_id
 
-    map_width = 1
-    map_height = 1
-    map_points_df = pd.DataFrame([{"number": None}])
-    if use_images:
-        source_path = prompt_digit_ocr_source()
-        OCR = load_digit_ocr(source_path)
+    return RunContext(
+        config_dict=config_dict,
+        version=version,
+        analysis_version=analysis_version,
+        subject_name=subject_name,
+        save_dir_path=save_dir_path,
+        db_path=db_path,
+        db=db,
+        meta_id=meta_id,
+        analysis_id=analysis_id,
+        use_f32=use_f32,
+        ic_bool=ic_bool,
+        ic_only=ic_only,
+        ic_points_df=ic_points_df,
+        final_file_df=final_file_df,
+        return_sdf=return_sdf,
+    )
 
-        _, points_image = _load_grayscale_image(
-            "Select Map Points image", "Select map POINTS image:"
+
+def _map_dimension_from_coords(values):
+    dimension = values.max() * 1000
+    return int(dimension + (dimension * 0.1))
+
+
+def _ingest_map_points_from_images(run_ctx):
+    source_path = prompt_digit_ocr_source()
+    if source_path is None:
+        cli.warn("Analysis canceled before choosing an OCR source.")
+        return None
+    ocr = load_digit_ocr(source_path)
+
+    _, points_image = _load_grayscale_image(
+        "Select Map Points image", "Select map POINTS image:"
+    )
+    if points_image is None:
+        cli.warn("Analysis canceled before choosing a map points image.")
+        return None
+    points_binary = points_image < 128
+    points_label = label(points_binary)
+    points_regions = regionprops(points_label)
+
+    number_data = load_number_mask_data()
+    if number_data is None:
+        cli.warn("Analysis canceled before choosing map numbers/mask images.")
+        return None
+    numbers_image = number_data["numbers_image"]
+    norm_row_max, norm_col_max = numbers_image.shape
+    mask_regions = number_data["mask_regions"]
+    number_crops = number_data["number_crops"]
+
+    if len(mask_regions) != len(points_regions):
+        raise AssertionError(
+            "Unequal number of Points and Numbers.\n "
+            "Were these files made correctly?"
         )
-        if points_image is None:
-            raise FileNotFoundError("No map points image selected.")
-        points_binary = points_image < 128
-        points_label = label(points_binary)
-        points_regions = regionprops(points_label)
 
-        number_data = load_number_mask_data()
-        if number_data is None:
-            raise FileNotFoundError("Map numbers/mask image selection was canceled.")
-        numbers_image = number_data["numbers_image"]
-        norm_row_max, norm_col_max = numbers_image.shape
-        mask_regions = number_data["mask_regions"]
-        number_crops = number_data["number_crops"]
+    map_height, map_width = points_image.shape
+    points_centroids = np.array([r.centroid for r in points_regions])
+    results = []
+    for mask_props, crop in zip(mask_regions, number_crops):
+        ocr_result = ocr.recognize(crop)
 
-        if len(mask_regions) != len(points_regions):
-            raise AssertionError(
-                "Unequal number of Points and Numbers.\n "
-                "Were these files made correctly?"
-            )
+        distances = np.linalg.norm(
+            points_centroids - np.array(mask_props.centroid), axis=1)
+        point = points_centroids[np.argmin(distances)]
+        ocr_result.metadata["x"] = point[1] / norm_col_max
+        ocr_result.metadata["y"] = 1 - (point[0] / norm_row_max)
+        results.append(ocr_result)
 
-        map_height, map_width = points_image.shape
-        points_centroids = np.array([r.centroid for r in points_regions])
-        results = []
-        for mask_props, crop in zip(mask_regions, number_crops):
-            ocr_result = OCR.recognize(crop)
+    ocr.review_results(results)
+    if cli.ask_yes_no("Save coordinates to .csv file [y/n]? > "):
+        csv_path = choose_csv_save_path(
+            run_ctx.save_dir_path, f"{run_ctx.subject_name}_coords.csv"
+        )
+        if csv_path is None:
+            cli.warn("CSV export canceled.")
+        else:
+            ocr.export_results_csv(results, csv_path)
 
-            distances = np.linalg.norm(
-                points_centroids - np.array(mask_props.centroid), axis=1)
-            point = points_centroids[np.argmin(distances)]
-            ocr_result.metadata["x"] = point[1] / norm_col_max
-            ocr_result.metadata["y"] = 1 - (point[0] / norm_row_max)
-            results.append(ocr_result)
-
-        OCR.review_results(results)
-        if cli.ask_yes_no("Save coordinates to .csv file [y/n]? > "):
-            csv_path = choose_csv_save_path(
-                save_dir_path, f"{subject_name}_coords.csv"
-            )
-            if csv_path is None:
-                cli.warn("CSV export canceled.")
-            else:
-                OCR.export_results_csv(results, csv_path)
-        map_points_df = pd.DataFrame(
+    return MapData(
+        map_points_df=pd.DataFrame(
             [{"number": r.number, "x": r.metadata["x"], "y": r.metadata["y"]}
              for r in results]
-        )
+        ),
+        map_width=map_width,
+        map_height=map_height,
+    )
 
-    elif not ic_only:
-        if image_or_point_list == "f":
-            cli.info(
-                "Select spreadsheet containing 'final file' format data:"
-            )
-            coords_sheet = afunc.get_file(title="Select final file",
-                                          filetypes=[("Excel workbook", ".xlsx")])
-            map_points_df = pd.read_excel(coords_sheet,
-                                          header=None,
-                                          usecols=[40, 41, 43],
-                                          names=["x", "y", "number"],
-                                          engine="openpyxl")
-        elif image_or_point_list == "c":
-            cli.info("Select .csv file with cols number,x,y (no headers):")
-            coords_sheet = afunc.get_file(title="Select Map number,x,y file",
-                                          filetypes=[("CSV", ".csv")])
-            map_points_df = pd.read_csv(coords_sheet,
-                                        header=None,
-                                        names=["number", "x", "y"])
 
-        map_width = map_points_df.x.max() * 1000
-        map_width = int(map_width + (map_width * 0.1))
-        map_height = map_points_df.y.max() * 1000
-        map_height = int(map_height + (map_height * 0.1))
+def _ingest_map_points_from_final_sheet():
+    cli.info("Select spreadsheet containing 'final file' format data:")
+    coords_sheet = afunc.get_file(title="Select final file",
+                                  filetypes=[("Excel workbook", ".xlsx")])
+    if not coords_sheet:
+        return None
 
-    db_metadata.update_one({"_id": meta_id},
-                           {"$set": {"map_height": map_height,
-                                     "map_width": map_width}})
+    map_points_df = pd.read_excel(coords_sheet,
+                                  header=None,
+                                  usecols=[40, 41, 43],
+                                  names=["x", "y", "number"],
+                                  engine="openpyxl")
+    return MapData(
+        map_points_df=map_points_df,
+        map_width=_map_dimension_from_coords(map_points_df.x),
+        map_height=_map_dimension_from_coords(map_points_df.y),
+    )
 
-    if not ic_only:
-        max_coor = map_points_df[["x", "y"]].max().values.max()
-        map_points_df[["x", "y"]] = map_points_df[["x", "y"]].apply(
-            lambda x: afunc.scale_coordinates(input_coor=x,
-                                              min_coor=0,
-                                              max_coor=max_coor,
-                                              min_scale=0.1,
-                                              max_scale=0.9))
 
-        print("Working on voronoi data...")
-        sites_list, bonus_pts = afunc.pick_voronoi(map_points_df,
-                                                   map_width, map_height)
-        cli.success("Saving map sites / voronoi data ... \n\n")
-        db_sites.insert_many(sites_list)
+def _ingest_map_points_from_csv():
+    cli.info("Select .csv file with cols number,x,y (no headers):")
+    coords_sheet = afunc.get_file(title="Select Map number,x,y file",
+                                  filetypes=[("CSV", ".csv")])
+    if not coords_sheet:
+        return None
 
+    map_points_df = pd.read_csv(coords_sheet,
+                                header=None,
+                                names=["number", "x", "y"])
+    return MapData(
+        map_points_df=map_points_df,
+        map_width=_map_dimension_from_coords(map_points_df.x),
+        map_height=_map_dimension_from_coords(map_points_df.y),
+    )
+
+
+def _persist_map_data(run_ctx, map_data):
+    run_ctx.db.metadata.update_one(
+        {"_id": run_ctx.meta_id},
+        {"$set": {"map_height": map_data.map_height,
+                  "map_width": map_data.map_width}},
+    )
+
+    if run_ctx.ic_only:
+        return map_data
+
+    scaled_map_points_df = map_data.map_points_df.copy()
+    max_coor = scaled_map_points_df[["x", "y"]].max().values.max()
+    scaled_map_points_df[["x", "y"]] = scaled_map_points_df[["x", "y"]].apply(
+        lambda x: afunc.scale_coordinates(input_coor=x,
+                                          min_coor=0,
+                                          max_coor=max_coor,
+                                          min_scale=0.1,
+                                          max_scale=0.9))
+
+    print("Working on voronoi data...")
+    sites_list, _ = afunc.pick_voronoi(scaled_map_points_df,
+                                       map_data.map_width,
+                                       map_data.map_height)
+    cli.success("Saving map sites / voronoi data ... \n\n")
+    run_ctx.db.sites.insert_many(sites_list)
+    return MapData(
+        map_points_df=scaled_map_points_df,
+        map_width=map_data.map_width,
+        map_height=map_data.map_height,
+    )
+
+
+def ingest_map_points(run_ctx):
+    if run_ctx.ic_only:
+        return _persist_map_data(run_ctx, MapData(map_points_df=_empty_number_df()))
+
+    map_point_source = cli.ask_choice(
+        "Using [i]mages, [f]inal file, or .[c]sv for map point data? > ",
+        ("i", "f", "c")
+    )
+    if map_point_source == "i":
+        map_data = _ingest_map_points_from_images(run_ctx)
+    elif map_point_source == "f":
+        map_data = _ingest_map_points_from_final_sheet()
+    else:
+        map_data = _ingest_map_points_from_csv()
+
+    if map_data is None:
+        cli.warn("Analysis canceled before loading map-point data.")
+        return None
+
+    return _persist_map_data(run_ctx, map_data)
+
+
+def _analysis_numbers(run_ctx, map_data):
+    if run_ctx.final_file_df is not None:
+        return run_ctx.final_file_df.number.values
+    if map_data is not None:
+        return map_data.map_points_df.number.values
+    return _empty_number_df().number.values
+
+
+def run_brainware_analysis(run_ctx, map_data=None):
     cli.info(
         "Select dir containing all Brainware files for subject"
         "(subfolders will be skipped):"
     )
     dir_path = afunc.get_folder(title="Select Brainware data dir")
+    if not dir_path:
+        cli.warn("Analysis canceled before choosing a Brainware data folder.")
+        return False
 
-    nums = map_points_df.number.values
-    ic_pens = ic_points_df.number.values if ic_bool else []
-    enabled_stims = enabled_stim_types(config_dict)
-    bw_files = _gather_brainware_files(dir_path, enabled_stims, use_f32,
-                                       nums, ic_pens, config_dict)
+    nums = _analysis_numbers(run_ctx, map_data)
+    ic_pens = run_ctx.ic_points_df.number.values if run_ctx.ic_bool else []
+    enabled_stims = enabled_stim_types(run_ctx.config_dict)
+    bw_files = _gather_brainware_files(dir_path, enabled_stims,
+                                       run_ctx.use_f32, nums, ic_pens,
+                                       run_ctx.config_dict)
 
     for stim in enabled_stims:
         files = bw_files.get(stim.key)
@@ -484,10 +613,10 @@ def run_program(config_dict, version, final_file=None, return_sdf=True):
 
         total = len(files)
         worker_kwargs = stim.worker_kwargs(
-            config_dict,
-            analysis_id=analysis_id,
-            final_file=final_file,
-            return_sdf=return_sdf,
+            run_ctx.config_dict,
+            analysis_id=run_ctx.analysis_id,
+            final_file_df=run_ctx.final_file_df,
+            return_sdf=run_ctx.return_sdf,
         )
 
         @ray.remote
@@ -496,14 +625,33 @@ def run_program(config_dict, version, final_file=None, return_sdf=True):
                 idx=idx,
                 file=file,
                 total=total,
-                use_f32=use_f32,
+                use_f32=run_ctx.use_f32,
                 ic_pens=ic_pens,
                 **worker_kwargs,
             )
 
         results = ray.get([worker.remote(i, f) for i, f in enumerate(files)])
         cli.success(f"\nSaving {stim.label} data...")
-        _route_and_insert(results, stim, db, ic_bool, ic_pens, ic_points_df)
+        _route_and_insert(results, stim, run_ctx.db, run_ctx.ic_bool,
+                          ic_pens, run_ctx.ic_points_df)
 
-    db.close()
     return True
+
+
+def run_program(config_dict, version, final_file_df=None, return_sdf=True):
+    run_ctx = prepare_run_context(config_dict, version,
+                                  final_file_df=final_file_df,
+                                  return_sdf=return_sdf)
+    if run_ctx is None:
+        return False
+
+    try:
+        map_data = None
+        if run_ctx.final_file_df is None:
+            map_data = ingest_map_points(run_ctx)
+            if map_data is None:
+                return False
+
+        return run_brainware_analysis(run_ctx, map_data=map_data)
+    finally:
+        run_ctx.db.close()

--- a/tests/test_brainware.py
+++ b/tests/test_brainware.py
@@ -1,0 +1,86 @@
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+from neo.io.brainwaresrcio import BrainwareSrcIO
+
+from brainware import get_spike_dict, prettify_spike_dict
+
+
+def _fake_spiketrain(times):
+    return SimpleNamespace(
+        times=SimpleNamespace(
+            magnitude=SimpleNamespace(tolist=lambda: list(times))
+        )
+    )
+
+
+class BrainwareParsingTests(unittest.TestCase):
+    def test_get_spike_dict_falls_back_to_non_unassigned_group_spikes(self):
+        blk = SimpleNamespace(
+            file_origin="demo.src",
+            segments=[
+                SimpleNamespace(annotations={}, spiketrains=[]),
+                SimpleNamespace(
+                    annotations={"freq [Hz]": 1000, "int [dB]": 20},
+                    spiketrains=[],
+                ),
+                SimpleNamespace(
+                    annotations={"freq [Hz]": 1000, "int [dB]": 20},
+                    spiketrains=[],
+                ),
+            ],
+            groups=[
+                SimpleNamespace(name="UnassignedSpikes",
+                                spiketrains=[_fake_spiketrain([]),
+                                             _fake_spiketrain([])]),
+                SimpleNamespace(name="C62",
+                                spiketrains=[_fake_spiketrain([]),
+                                             _fake_spiketrain([2.0])]),
+            ],
+        )
+
+        spike_dict = get_spike_dict(blk, use_f32=False, dataset="densetc")
+
+        self.assertEqual(dict(spike_dict), {(1000, 20): [[], [2.0]]})
+
+    def test_demo_src_matches_known_site_1_sweeps(self):
+        demo_file = Path(__file__).resolve().parent.parent / "demo" / "data" / \
+            "DenseTC_singleRP2#001G_RZ5-1_007.src"
+        blk = BrainwareSrcIO(filename=str(demo_file)).read_all_blocks()[0]
+
+        pretty = prettify_spike_dict(
+            get_spike_dict(blk, use_f32=False, dataset="densetc"),
+            dataset="densetc",
+        )
+
+        self.assertEqual(
+            pretty[:3],
+            [
+                {"spikes_ms": [[]], "frequency_hz": 1000, "intensity_db": 75},
+                {
+                    "spikes_ms": [[
+                        15.032320022583008,
+                        15.851519584655762,
+                        16.99839973449707,
+                    ]],
+                    "frequency_hz": 1044,
+                    "intensity_db": 75,
+                },
+                {
+                    "spikes_ms": [[
+                        14.172160148620605,
+                        15.851519584655762,
+                        305.7254333496094,
+                        307.9372863769531,
+                        308.3878479003906,
+                    ]],
+                    "frequency_hz": 1090,
+                    "intensity_db": 75,
+                },
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`subject_analysis.run_program()` has been doing at least three distinct phases with pretty clean seams:
- setup/prompting: subject name, save path, db path, file type, IC options
- map ingestion + OCR/CSV/final-sheet + voronoi
- Brainware file discovery + per-stimulus analysis

This PR splits it into separate sections:
- `prepare_run_context()` handles the interactive subject/path/IC setup and DB bootstrap
- `ingest_map_points()` owns the image OCR / CSV / final-sheet map ingestion plus voronoi persistence
- `run_brainware_analysis()` owns the per-stimulus Brainware pass

`[g]` in `map_analysis.py` can now go through setup and jump straight to `run_brainware_analysis()`

Also added `RunContext` / `MapData`, renamed the ambiguous `final_file` plumbing to `final_file_df`, and fixed Brainware file collection to use `entry.path`.

Running a full analysis finally after all the refactors revealed some new issues though:
- `neo` had a breaking change in how it provided access to spiketrains. An update to `get_spike_dict` enables parsing current `neo` version as well as the older path.
- Enabling SVML crashed the ray workers, made it an optional OS toggle
- Something with the `bayesian_bins.py` math has busted and is producing 95% garbage, 5% correct latency estimates. Created #70 to begin to address the issue

Also included is a misc fix to file dialogs so that the picker starts either in the CWD or last used dir rather than requiring navigation from home dir to X, and a `nox` based `pytest` run (with some new brainware spike parsing tests).