### PR TITLE
Fix and update bayesian bins

### DIFF
--- a/docs/bayesian_bins.md
+++ b/docs/bayesian_bins.md
@@ -1,0 +1,202 @@
+# Bayesian Bins Notes
+
+This document is for maintainers touching `bayesian_bins.py`, DenseTC
+latency detection, or the benchmark/regression tooling around them.
+
+## What Lives Where
+
+`src/bayesian_bins.py` is intended to stay close to the original C++ Bayesian
+Bins / SDF algorithm. Its defaults should be generic and C++-ish where possible.
+
+`src/stim_types/densetc.py` owns the auditory-neurophysiology policy choices
+that worked best for DenseTC analysis:
+
+- `max_t=250`
+- `max_m=10`
+- `lat_start=1`
+- `lat_end=150`
+- `l_bound=4`
+- signal separator buckets based on spontaneous firing rate
+- the SDF-derived offset heuristic
+
+The split is intentional. If a choice is specific to this project's DenseTC
+maps, keep it in `densetc.py`; if it is part of the general algorithm, keep it
+in `bayesian_bins.py`.
+
+## C++ Mapping
+
+The old C++ source separates a few concepts that are easy to blur together:
+
+- The beta prior hyperparameters are `efire` and `egap`.
+- The optional simplex optimizer is for those prior hyperparameters.
+- The latency signal separator is optimized separately with golden-section
+  search.
+- The C++ separator search uses roughly `0.0..0.1` by default.
+
+In Python naming, `sigma` and `gamma` play the role of beta prior exponents.
+DenseTC usually estimates them from spontaneous rate instead of fitting them.
+
+## Current DenseTC Baseline
+
+The current default DenseTC behavior intentionally preserves the frozen demo
+auto-analysis:
+
+```bash
+./src/.venv/bin/python scripts/benchmark_bayesian_bins.py \
+  --analysis frozen \
+  --sites 72 \
+  --check-only
+```
+
+Expected result:
+
+```text
+latency_matches=72/72
+component_matches=onset:72/72 peak:72/72 offset:72/72
+```
+
+The same defaults compared with the manually corrected demo analysis currently
+produce:
+
+```bash
+./src/.venv/bin/python scripts/benchmark_bayesian_bins.py \
+  --analysis manual \
+  --sites 72 \
+  --check-only \
+  --show-mismatches 10
+```
+
+Expected result:
+
+```text
+latency_matches=53/72
+component_matches=onset:66/72 peak:72/72 offset:56/72
+mean_abs_ms=onset:0.17 peak:0.00 offset:2.60
+```
+
+Most manual mismatches are offset differences, not peak or Bayesian onset
+failures.
+
+## Slow Regression Check
+
+Before changing Bayesian Bins, DenseTC latency defaults, or offset logic, run:
+
+```bash
+uv tool run --with 'nox[uv]' nox -s bayesian-bins
+```
+
+That nox session runs the frozen and manual demo comparisons with expected
+counts. It is intentionally slower than the normal unit tests because it runs
+the full SDF path across all 72 demo DenseTC sites.
+
+For a quicker direct run without nox environment setup:
+
+```bash
+./src/.venv/bin/python scripts/benchmark_bayesian_bins.py \
+  --analysis frozen \
+  --sites 72 \
+  --check-only \
+  --expect-latency-matches 72 \
+  --expect-onset-matches 72 \
+  --expect-peak-matches 72 \
+  --expect-offset-matches 72
+```
+
+## Timing Benchmark
+
+Use the benchmark script to compare worktree performance against an older ref:
+
+```bash
+./src/.venv/bin/python scripts/benchmark_bayesian_bins.py \
+  --analysis frozen \
+  --sites 3 \
+  --repeats 2 \
+  --ref HEAD~3
+```
+
+Useful modes:
+
+```bash
+# Time latency-only analysis.
+./src/.venv/bin/python scripts/benchmark_bayesian_bins.py \
+  --analysis frozen \
+  --sites 10 \
+  --repeats 2 \
+  --mode no-sdf \
+  --skip-latency-check
+
+# Time the full SDF path.
+./src/.venv/bin/python scripts/benchmark_bayesian_bins.py \
+  --analysis frozen \
+  --sites 10 \
+  --repeats 1 \
+  --mode sdf
+```
+
+## Parameter Sweeps
+
+The benchmark script can compare algorithm parameters against either frozen or
+manual saved analyses.
+
+Signal separator bounds:
+
+```bash
+# DenseTC auditory defaults.
+./src/.venv/bin/python scripts/benchmark_bayesian_bins.py \
+  --analysis manual \
+  --sites 72 \
+  --check-only \
+  --signal-bounds densetc
+
+# C++-style broad separator search.
+./src/.venv/bin/python scripts/benchmark_bayesian_bins.py \
+  --analysis manual \
+  --sites 72 \
+  --check-only \
+  --signal-bounds cxx
+
+# Custom signal separator range.
+./src/.venv/bin/python scripts/benchmark_bayesian_bins.py \
+  --analysis manual \
+  --sites 72 \
+  --check-only \
+  --signal-bounds custom \
+  --min-sig-bound 0.001 \
+  --max-sig-bound 0.025
+```
+
+Offset heuristic sweep:
+
+```bash
+./src/.venv/bin/python scripts/benchmark_bayesian_bins.py \
+  --analysis manual \
+  --sites 72 \
+  --check-only \
+  --sweep-offset \
+  --sweep-top 10
+```
+
+Current finding: `offset_min_run=9` slightly improves manual offset MAE, but it
+breaks frozen exact matching. Keep the production default at `offset_min_run=10`
+unless there is a deliberate decision to prioritize manual-style offsets over
+frozen auto-analysis compatibility.
+
+## Known Findings
+
+- Disabling broad `fastmath` on `nb_max_logsumexp` fixed the all-`-inf` to
+  `nan` failure mode that broke on newer dependency versions.
+- Cached interval evidence and cached signal-dependent beta logs give major
+  speedups over previous Python version used.
+- Widening DenseTC separator bounds to C++-style `0.0..0.1` made demo matches
+  worse.
+- Changing DenseTC `l_bound` from `4` to `1` did not improve demo matches.
+- Lowering `max_m` hurt demo matches.
+- The remaining manual-vs-auto gap is mostly offset cleanup, not Bayesian onset
+  or peak detection.
+
+## Future Work
+
+- Add an optional prior-hyperparameter fitter mirroring the C++ simplex path.
+- Revisit Ray plus Numba thread settings so outer process parallelism and inner
+  Numba parallelism do not oversubscribe CPUs.
+- Re-evaluate SVML as an opt-in acceleration path on supported platforms only.

--- a/docs/bayesian_bins.md
+++ b/docs/bayesian_bins.md
@@ -36,6 +36,50 @@ The old C++ source separates a few concepts that are easy to blur together:
 In Python naming, `sigma` and `gamma` play the role of beta prior exponents.
 DenseTC usually estimates them from spontaneous rate instead of fitting them.
 
+## Optional Prior Fitting
+
+`bayesian_bins.fit_prior_exponents()` mirrors the optional original C++ simplex path for fitting beta prior exponents. It uses SciPy's Nelder-Mead optimizer over:
+
+- `gamma`, equivalent to C++ `egap`
+- `sigma`, equivalent to C++ `efire`
+
+The objective follows the C++ code:
+
+- maximize total evidence, `P(D)`
+- include the same weak gamma-prior-style penalty over firing probability and
+  prior magnitude
+- constrain `gamma` to `1..300`
+- constrain `sigma` to `0.001..300`
+
+This is diagnostic/experimental. DenseTC defaults do not enable it.
+
+Example:
+
+```python
+import bayesian_bins as bb
+
+fit = bb.fit_prior_exponents(
+    psth,
+    n_sweeps,
+    max_t=250,
+    max_m=10,
+)
+print(fit["sigma"], fit["gamma"], fit["firing_prob"])
+```
+
+To run an analysis with fitted priors:
+
+```python
+result = bb.analyze_psth(
+    psth,
+    n_sweeps,
+    max_t=250,
+    max_m=10,
+    fit_priors=True,
+)
+print(result["prior_fit"])
+```
+
 ## Current DenseTC Baseline
 
 The current default DenseTC behavior intentionally preserves the frozen demo
@@ -181,6 +225,20 @@ breaks frozen exact matching. Keep the production default at `offset_min_run=10`
 unless there is a deliberate decision to prioritize manual-style offsets over
 frozen auto-analysis compatibility.
 
+Prior fitting sweep:
+
+```bash
+./src/.venv/bin/python scripts/benchmark_bayesian_bins.py \
+  --analysis manual \
+  --sites 3 \
+  --check-only \
+  --fit-priors \
+  --prior-fit-maxiter 50
+```
+
+Keep site counts low while experimenting. Fitting priors runs an optimizer for
+each site, and each objective evaluation recomputes Bayesian evidence.
+
 ## Known Findings
 
 - Disabling broad `fastmath` on `nb_max_logsumexp` fixed the all-`-inf` to
@@ -196,7 +254,7 @@ frozen auto-analysis compatibility.
 
 ## Future Work
 
-- Add an optional prior-hyperparameter fitter mirroring the C++ simplex path.
+- Compare fitted-prior analyses against frozen/manual demo targets.
 - Revisit Ray plus Numba thread settings so outer process parallelism and inner
   Numba parallelism do not oversubscribe CPUs.
 - Re-evaluate SVML as an opt-in acceleration path on supported platforms only.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -58,3 +58,21 @@ You can also install the full version set up front:
 uv python install 3.10 3.11 3.12
 uv tool run --with 'nox[uv]' nox -s smoke
 ```
+
+## Running pytest on `./tests/`
+
+```bash
+uv tool run --with 'nox[uv]' nox -s tests
+```
+
+## Slow Bayesian Bins Regression
+
+Run this before changing Bayesian Bins, DenseTC latency defaults, or SDF offset
+logic:
+
+```bash
+uv tool run --with 'nox[uv]' nox -s bayesian-bins
+```
+
+See [Bayesian Bins Notes](bayesian_bins.md) for benchmark commands, expected
+frozen/manual demo scores, and parameter sweep examples.

--- a/noxfile.py
+++ b/noxfile.py
@@ -26,6 +26,32 @@ def tests(session: nox.Session) -> None:
     session.run("pytest")
 
 
+@nox.session(name="bayesian-bins", python="3.12")
+def bayesian_bins(session: nox.Session) -> None:
+    session.install("-e", ".")
+    benchmark = str(Path("scripts") / "benchmark_bayesian_bins.py")
+    session.run(
+        "python", benchmark,
+        "--analysis", "frozen",
+        "--sites", "72",
+        "--check-only",
+        "--expect-latency-matches", "72",
+        "--expect-onset-matches", "72",
+        "--expect-peak-matches", "72",
+        "--expect-offset-matches", "72",
+    )
+    session.run(
+        "python", benchmark,
+        "--analysis", "manual",
+        "--sites", "72",
+        "--check-only",
+        "--expect-latency-matches", "53",
+        "--expect-onset-matches", "66",
+        "--expect-peak-matches", "72",
+        "--expect-offset-matches", "56",
+    )
+
+
 @nox.session(name="smoke", python=SUPPORTED_PYTHONS)
 def smoke(session: nox.Session) -> None:
     _run_smoke(session)

--- a/scripts/benchmark_bayesian_bins.py
+++ b/scripts/benchmark_bayesian_bins.py
@@ -59,6 +59,10 @@ def parse_args():
     parser.add_argument("--expect-onset-matches", type=int)
     parser.add_argument("--expect-peak-matches", type=int)
     parser.add_argument("--expect-offset-matches", type=int)
+    parser.add_argument("--fit-priors", action="store_true")
+    parser.add_argument("--prior-fit-maxiter", type=int, default=200)
+    parser.add_argument("--initial-sigma", type=float)
+    parser.add_argument("--initial-gamma", type=float)
     return parser.parse_args()
 
 
@@ -141,6 +145,11 @@ def analyze_site(module, site, n_sweeps, return_sdf, args):
     min_sig_bound, max_sig_bound = get_signal_bounds(
         args, site["spont_firing_rate_hz"])
     u_bound = args.u_bound if args.u_bound is not None else args.max_m
+    prior_fit_options = {"maxiter": args.prior_fit_maxiter}
+    if args.initial_sigma is not None:
+        prior_fit_options["initial_sigma"] = args.initial_sigma
+    if args.initial_gamma is not None:
+        prior_fit_options["initial_gamma"] = args.initial_gamma
 
     return module.analyze_psth(
         np.array(site["psth"], dtype=np.int64),
@@ -155,6 +164,8 @@ def analyze_site(module, site, n_sweeps, return_sdf, args):
         min_sig_bound=min_sig_bound,
         max_sig_bound=max_sig_bound,
         return_sdf=return_sdf,
+        fit_priors=args.fit_priors,
+        prior_fit_options=prior_fit_options,
     )
 
 

--- a/scripts/benchmark_bayesian_bins.py
+++ b/scripts/benchmark_bayesian_bins.py
@@ -47,6 +47,14 @@ def parse_args():
         default="densetc")
     parser.add_argument("--min-sig-bound", type=float)
     parser.add_argument("--max-sig-bound", type=float)
+    parser.add_argument("--offset-mean-atol", type=float, default=1e-2)
+    parser.add_argument("--offset-std-scale", type=float, default=1.0)
+    parser.add_argument("--offset-min-run", type=int, default=10)
+    parser.add_argument("--offset-adjust-ms", type=int, default=0)
+    parser.add_argument("--sweep-offset", action="store_true")
+    parser.add_argument("--sweep-min-run-range", default="1:15")
+    parser.add_argument("--sweep-adjust-range", default="-15:5")
+    parser.add_argument("--sweep-top", type=int, default=15)
     return parser.parse_args()
 
 
@@ -146,7 +154,45 @@ def analyze_site(module, site, n_sweeps, return_sdf, args):
     )
 
 
-def get_densetc_lats_from_result(site, result, lat_start):
+def get_densetc_offset(sdf, onset, args, default_offset=300):
+    d_sdf = np.diff(sdf)
+    d_sdf_range = np.ptp(d_sdf)
+    if d_sdf_range == 0:
+        return default_offset
+
+    d_norm_sdf = 2.0 * (d_sdf - np.min(d_sdf)) / d_sdf_range - 1
+    norm_mean = np.mean(d_norm_sdf)
+    norm_std = np.std(d_norm_sdf)
+    equals_mean = np.isclose(d_norm_sdf[onset:], norm_mean,
+                             atol=args.offset_mean_atol)
+    offsets = np.where(
+        d_norm_sdf[onset:] <
+        (norm_mean - args.offset_std_scale * norm_std))[0]
+    if offsets.any():
+        potential_offsets = np.where(equals_mean[offsets[0]:] == 1)[0]
+        if potential_offsets.any():
+            seqs = 1 + np.where(np.diff(potential_offsets) != 1)[0]
+            offset_seqs = np.split(potential_offsets, seqs)
+            passing_offsets = np.where(
+                np.array([len(x) for x in offset_seqs]) >=
+                args.offset_min_run)[0]
+            if passing_offsets.any():
+                offset = int(
+                    offset_seqs[passing_offsets[0]][0] + offsets[0] + onset)
+            else:
+                offset = int(offset_seqs[-1][0] + offsets[0] + onset)
+        else:
+            offset = int(offsets[0] + onset)
+    else:
+        offset = default_offset
+
+    if offset != default_offset and args.offset_adjust_ms:
+        offset = max(onset + 1, offset + args.offset_adjust_ms)
+        offset = min(default_offset, offset)
+    return offset
+
+
+def get_densetc_lats_from_result(site, result, lat_start, args):
     psth = np.array(site["psth"], dtype=np.int64)
     sdf = result["sdf"]
     lats = np.nan_to_num(result["lats"][lat_start:], nan=0.0, posinf=1.0,
@@ -163,42 +209,19 @@ def get_densetc_lats_from_result(site, result, lat_start):
     if (total_prob < 0.2) or (max_prob < 0.1):
         return 50, None, 300
 
-    d_sdf = np.diff(sdf)
-    d_norm_sdf = 2.0 * (d_sdf - np.min(d_sdf)) / np.ptp(d_sdf) - 1
-    norm_mean = np.mean(d_norm_sdf)
-    norm_std = np.std(d_norm_sdf)
-    equals_mean = np.isclose(d_norm_sdf[onset:], norm_mean, atol=1e-2)
-    offsets = np.where(d_norm_sdf[onset:] < (norm_mean - norm_std))[0]
-    if offsets.any():
-        potential_offsets = np.where(equals_mean[offsets[0]:] == 1)[0]
-        if potential_offsets.any():
-            seqs = 1 + np.where(np.diff(potential_offsets) != 1)[0]
-            offset_seqs = np.split(potential_offsets, seqs)
-            passing_offsets = np.where(
-                np.array([len(x) for x in offset_seqs]) >= 10)[0]
-            if passing_offsets.any():
-                offset = int(
-                    offset_seqs[passing_offsets[0]][0] + offsets[0] + onset)
-            else:
-                offset = int(offset_seqs[-1][0] + offsets[0] + onset)
-        else:
-            offset = int(offsets[0] + onset)
-    else:
-        offset = 300
-
+    offset = get_densetc_offset(sdf, onset, args)
     peak = int(np.argmax(psth[onset:offset])) + onset
     return onset, peak, offset
 
 
-def check_latencies(module, sites, n_sweeps, args):
+def score_latencies(site_results, args):
     matches = 0
     mismatches = []
     component_matches = {"onset": 0, "peak": 0, "offset": 0}
     abs_errors = {"onset": [], "peak": [], "offset": []}
-    for site in sites:
-        result = analyze_site(module, site, n_sweeps, return_sdf=True,
-                              args=args)
-        got = get_densetc_lats_from_result(site, result, args.lat_start)
+    for site, result in site_results:
+        got = get_densetc_lats_from_result(
+            site, result, args.lat_start, args)
         expected = (site["onset_ms"], site["peak_ms"], site["offset_ms"])
         for idx, key in enumerate(("onset", "peak", "offset")):
             if got[idx] == expected[idx]:
@@ -210,6 +233,52 @@ def check_latencies(module, sites, n_sweeps, args):
         else:
             mismatches.append((site["number"], expected, got))
     return matches, mismatches, component_matches, abs_errors
+
+
+def check_latencies(module, sites, n_sweeps, args):
+    site_results = [
+        (site, analyze_site(module, site, n_sweeps, return_sdf=True,
+                            args=args))
+        for site in sites
+    ]
+    return score_latencies(site_results, args)
+
+
+def parse_int_range(value):
+    start, end = (int(part) for part in value.split(":", maxsplit=1))
+    step = 1 if start <= end else -1
+    return range(start, end + step, step)
+
+
+def sweep_offsets(module, sites, n_sweeps, args):
+    site_results = [
+        (site, analyze_site(module, site, n_sweeps, return_sdf=True,
+                            args=args))
+        for site in sites
+    ]
+    rows = []
+    for offset_min_run in parse_int_range(args.sweep_min_run_range):
+        for offset_adjust_ms in parse_int_range(args.sweep_adjust_range):
+            sweep_args = types.SimpleNamespace(**vars(args))
+            sweep_args.offset_min_run = offset_min_run
+            sweep_args.offset_adjust_ms = offset_adjust_ms
+            score = score_latencies(site_results, sweep_args)
+            matches, _, component_matches, abs_errors = score
+            rows.append({
+                "offset_min_run": offset_min_run,
+                "offset_adjust_ms": offset_adjust_ms,
+                "matches": matches,
+                "offset_matches": component_matches["offset"],
+                "onset_matches": component_matches["onset"],
+                "peak_matches": component_matches["peak"],
+                "offset_mae": mean(abs_errors["offset"]),
+                "score": score,
+            })
+
+    rows.sort(key=lambda row: (
+        -row["matches"], row["offset_mae"], -row["offset_matches"],
+        abs(row["offset_adjust_ms"]), row["offset_min_run"]))
+    return rows
 
 
 def mean(values):
@@ -251,6 +320,20 @@ def main():
     for label in labels:
         module = load_module(label)
         print(f"\n[{label}]")
+        if args.sweep_offset:
+            rows = sweep_offsets(module, sites, n_sweeps, args)
+            for row in rows[:args.sweep_top]:
+                print(
+                    "offset_sweep "
+                    f"min_run={row['offset_min_run']} "
+                    f"adjust_ms={row['offset_adjust_ms']} "
+                    f"latency_matches={row['matches']}/{len(sites)} "
+                    f"component_matches="
+                    f"onset:{row['onset_matches']}/{len(sites)} "
+                    f"peak:{row['peak_matches']}/{len(sites)} "
+                    f"offset:{row['offset_matches']}/{len(sites)} "
+                    f"offset_mae={row['offset_mae']:.2f}")
+            continue
         if not args.skip_latency_check:
             matches, mismatches, component_matches, abs_errors = (
                 check_latencies(module, sites, n_sweeps, args)

--- a/scripts/benchmark_bayesian_bins.py
+++ b/scripts/benchmark_bayesian_bins.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Benchmark bayesian_bins against frozen demo PSTHs."""
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import statistics
+import subprocess
+import sys
+import time
+import types
+from pathlib import Path
+
+import numpy as np
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+DEFAULT_DEMO_JSON = ROOT / "demo" / "output" / "analyzed_demo.json"
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--demo-json", type=Path, default=DEFAULT_DEMO_JSON)
+    parser.add_argument("--sites", type=int, default=3)
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument(
+        "--mode", choices=("both", "sdf", "no-sdf"), default="both")
+    parser.add_argument(
+        "--ref", action="append", default=[],
+        help="Git ref to compare against, e.g. HEAD or main. May repeat.")
+    parser.add_argument("--skip-latency-check", action="store_true")
+    return parser.parse_args()
+
+
+def load_demo_sites(demo_json):
+    obj = json.loads(demo_json.read_text())
+    metadata = next(iter(obj["metadata"].values()))
+    n_sweeps = metadata["project_configuration"]["densetc_num_tones"]
+    frozen_id = next(
+        value["_id"]
+        for value in obj["analysis_metadata"].values()
+        if value.get("frozen")
+    )
+    docs = next(
+        value
+        for key, value in obj.items()
+        if "densetc_analysis" in key and "IC" not in key
+    )
+    sites = sorted(
+        (doc for doc in docs.values() if doc.get("analysis_id") == frozen_id),
+        key=lambda doc: doc["number"],
+    )
+    return sites, n_sweeps
+
+
+def load_module(label):
+    if label == "worktree":
+        if str(SRC) not in sys.path:
+            sys.path.insert(0, str(SRC))
+        return importlib.import_module("bayesian_bins")
+
+    source = subprocess.check_output(
+        ["git", "show", f"{label}:src/bayesian_bins.py"],
+        cwd=ROOT,
+        text=True,
+    )
+    module = types.ModuleType(f"bayesian_bins_{label.replace('/', '_')}")
+    module.__file__ = f"{label}:src/bayesian_bins.py"
+    exec(compile(source, module.__file__, "exec"), module.__dict__)
+    return module
+
+
+def analyze_site(module, site, n_sweeps, return_sdf):
+    return module.analyze_psth(
+        np.array(site["psth"], dtype=np.int64),
+        n_sweeps,
+        site["spont_firing_rate_hz"],
+        max_t=250,
+        max_m=10,
+        lat_start=1,
+        lat_end=150,
+        l_bound=4,
+        u_bound=10,
+        return_sdf=return_sdf,
+    )
+
+
+def get_densetc_lats_from_result(site, result):
+    psth = np.array(site["psth"], dtype=np.int64)
+    sdf = result["sdf"]
+    lats = result["lats"][1:]
+    max_prob = np.amax(lats)
+    onset = np.where(0.15 <= lats)[0]
+    if onset.any():
+        onset = int(onset[0] + 1)
+    else:
+        onset = int(np.argmax(lats) + 1)
+
+    if (result["total_prob"] < 0.2) or (max_prob < 0.1):
+        return onset, None, 300
+
+    d_sdf = np.diff(sdf)
+    d_norm_sdf = 2.0 * (d_sdf - np.min(d_sdf)) / np.ptp(d_sdf) - 1
+    norm_mean = np.mean(d_norm_sdf)
+    norm_std = np.std(d_norm_sdf)
+    equals_mean = np.isclose(d_norm_sdf[onset:], norm_mean, atol=1e-2)
+    offsets = np.where(d_norm_sdf[onset:] < (norm_mean - norm_std))[0]
+    if offsets.any():
+        potential_offsets = np.where(equals_mean[offsets[0]:] == 1)[0]
+        if potential_offsets.any():
+            seqs = 1 + np.where(np.diff(potential_offsets) != 1)[0]
+            offset_seqs = np.split(potential_offsets, seqs)
+            passing_offsets = np.where(
+                np.array([len(x) for x in offset_seqs]) >= 10)[0]
+            if passing_offsets.any():
+                offset = int(
+                    offset_seqs[passing_offsets[0]][0] + offsets[0] + onset)
+            else:
+                offset = int(offset_seqs[-1][0] + offsets[0] + onset)
+        else:
+            offset = int(offsets[0] + onset)
+    else:
+        offset = 300
+
+    peak = int(np.argmax(psth[onset:offset])) + onset
+    return onset, peak, offset
+
+
+def check_latencies(module, sites, n_sweeps):
+    matches = 0
+    for site in sites:
+        result = analyze_site(module, site, n_sweeps, return_sdf=True)
+        got = get_densetc_lats_from_result(site, result)
+        expected = (site["onset_ms"], site["peak_ms"], site["offset_ms"])
+        if got == expected and np.isfinite(result["lats"]).all():
+            matches += 1
+    return matches
+
+
+def bench(module, sites, n_sweeps, return_sdf, repeats):
+    analyze_site(module, sites[0], n_sweeps, return_sdf)
+    times = []
+    for _ in range(repeats):
+        start = time.perf_counter()
+        for site in sites:
+            analyze_site(module, site, n_sweeps, return_sdf)
+        times.append(time.perf_counter() - start)
+    return times
+
+
+def main():
+    args = parse_args()
+    sites, n_sweeps = load_demo_sites(args.demo_json)
+    sites = sites[:args.sites]
+    labels = ["worktree", *args.ref]
+    modes = []
+    if args.mode in ("both", "no-sdf"):
+        modes.append(("no_sdf", False))
+    if args.mode in ("both", "sdf"):
+        modes.append(("sdf", True))
+
+    print(f"sites={len(sites)} repeats={args.repeats} n_sweeps={n_sweeps}")
+    for label in labels:
+        module = load_module(label)
+        print(f"\n[{label}]")
+        if not args.skip_latency_check:
+            matches = check_latencies(module, sites, n_sweeps)
+            print(f"latency_matches={matches}/{len(sites)}")
+        for mode_label, return_sdf in modes:
+            times = bench(module, sites, n_sweeps, return_sdf, args.repeats)
+            median = statistics.median(times)
+            per_site = median / len(sites)
+            rounded = ", ".join(f"{value:.3f}" for value in times)
+            print(
+                f"{mode_label}: median={median:.3f}s "
+                f"per_site={per_site:.3f}s runs=[{rounded}]")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark_bayesian_bins.py
+++ b/scripts/benchmark_bayesian_bins.py
@@ -55,6 +55,10 @@ def parse_args():
     parser.add_argument("--sweep-min-run-range", default="1:15")
     parser.add_argument("--sweep-adjust-range", default="-15:5")
     parser.add_argument("--sweep-top", type=int, default=15)
+    parser.add_argument("--expect-latency-matches", type=int)
+    parser.add_argument("--expect-onset-matches", type=int)
+    parser.add_argument("--expect-peak-matches", type=int)
+    parser.add_argument("--expect-offset-matches", type=int)
     return parser.parse_args()
 
 
@@ -287,6 +291,14 @@ def mean(values):
     return statistics.mean(values)
 
 
+def check_expectation(label, actual, expected):
+    if expected is None:
+        return
+    if actual != expected:
+        raise SystemExit(
+            f"{label} expected {expected}, got {actual}")
+
+
 def bench(module, sites, n_sweeps, return_sdf, repeats, args):
     analyze_site(module, sites[0], n_sweeps, return_sdf, args)
     times = []
@@ -349,6 +361,17 @@ def main():
                 f"onset:{mean(abs_errors['onset']):.2f} "
                 f"peak:{mean(abs_errors['peak']):.2f} "
                 f"offset:{mean(abs_errors['offset']):.2f}")
+            check_expectation(
+                "latency_matches", matches, args.expect_latency_matches)
+            check_expectation(
+                "onset_matches", component_matches["onset"],
+                args.expect_onset_matches)
+            check_expectation(
+                "peak_matches", component_matches["peak"],
+                args.expect_peak_matches)
+            check_expectation(
+                "offset_matches", component_matches["offset"],
+                args.expect_offset_matches)
             if args.show_mismatches:
                 for number, expected, got in mismatches[:args.show_mismatches]:
                     print(

--- a/scripts/benchmark_bayesian_bins.py
+++ b/scripts/benchmark_bayesian_bins.py
@@ -90,16 +90,19 @@ def analyze_site(module, site, n_sweeps, return_sdf):
 def get_densetc_lats_from_result(site, result):
     psth = np.array(site["psth"], dtype=np.int64)
     sdf = result["sdf"]
-    lats = result["lats"][1:]
-    max_prob = np.amax(lats)
+    lats = np.nan_to_num(result["lats"][1:], nan=0.0, posinf=1.0,
+                         neginf=0.0)
+    max_prob = float(np.amax(lats))
     onset = np.where(0.15 <= lats)[0]
     if onset.any():
         onset = int(onset[0] + 1)
     else:
         onset = int(np.argmax(lats) + 1)
 
-    if (result["total_prob"] < 0.2) or (max_prob < 0.1):
-        return onset, None, 300
+    total_prob = float(np.nan_to_num(result["total_prob"], nan=0.0,
+                                     posinf=1.0, neginf=0.0))
+    if (total_prob < 0.2) or (max_prob < 0.1):
+        return 50, None, 300
 
     d_sdf = np.diff(sdf)
     d_norm_sdf = 2.0 * (d_sdf - np.min(d_sdf)) / np.ptp(d_sdf) - 1

--- a/scripts/benchmark_bayesian_bins.py
+++ b/scripts/benchmark_bayesian_bins.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Benchmark bayesian_bins against frozen demo PSTHs."""
+"""Benchmark bayesian_bins against demo PSTHs and saved latency analyses."""
 from __future__ import annotations
 
 import argparse
@@ -23,6 +23,9 @@ DEFAULT_DEMO_JSON = ROOT / "demo" / "output" / "analyzed_demo.json"
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--demo-json", type=Path, default=DEFAULT_DEMO_JSON)
+    parser.add_argument(
+        "--analysis", default="frozen",
+        help="Analysis target: frozen, manual, analysis _id, metadata key, or name.")
     parser.add_argument("--sites", type=int, default=3)
     parser.add_argument("--repeats", type=int, default=3)
     parser.add_argument(
@@ -31,28 +34,56 @@ def parse_args():
         "--ref", action="append", default=[],
         help="Git ref to compare against, e.g. HEAD or main. May repeat.")
     parser.add_argument("--skip-latency-check", action="store_true")
+    parser.add_argument("--check-only", action="store_true")
+    parser.add_argument("--show-mismatches", type=int, default=0)
+    parser.add_argument("--max-t", type=int, default=250)
+    parser.add_argument("--max-m", type=int, default=10)
+    parser.add_argument("--lat-start", type=int, default=1)
+    parser.add_argument("--lat-end", type=int, default=150)
+    parser.add_argument("--l-bound", type=int, default=4)
+    parser.add_argument("--u-bound", type=int)
+    parser.add_argument(
+        "--signal-bounds", choices=("densetc", "cxx", "custom"),
+        default="densetc")
+    parser.add_argument("--min-sig-bound", type=float)
+    parser.add_argument("--max-sig-bound", type=float)
     return parser.parse_args()
 
 
-def load_demo_sites(demo_json):
+def select_analysis_id(analysis_metadata, selector):
+    if selector == "frozen":
+        return next(
+            value["_id"] for value in analysis_metadata.values()
+            if value.get("frozen")
+        )
+    if selector == "manual":
+        return next(
+            value["_id"] for value in analysis_metadata.values()
+            if not value.get("frozen")
+        )
+
+    for key, value in analysis_metadata.items():
+        if selector in (key, value.get("_id"), value.get("name")):
+            return value["_id"]
+
+    raise ValueError(f"Unknown analysis target: {selector}")
+
+
+def load_demo_sites(demo_json, analysis):
     obj = json.loads(demo_json.read_text())
     metadata = next(iter(obj["metadata"].values()))
     n_sweeps = metadata["project_configuration"]["densetc_num_tones"]
-    frozen_id = next(
-        value["_id"]
-        for value in obj["analysis_metadata"].values()
-        if value.get("frozen")
-    )
+    analysis_id = select_analysis_id(obj["analysis_metadata"], analysis)
     docs = next(
         value
         for key, value in obj.items()
         if "densetc_analysis" in key and "IC" not in key
     )
     sites = sorted(
-        (doc for doc in docs.values() if doc.get("analysis_id") == frozen_id),
+        (doc for doc in docs.values() if doc.get("analysis_id") == analysis_id),
         key=lambda doc: doc["number"],
     )
-    return sites, n_sweeps
+    return sites, n_sweeps, analysis_id
 
 
 def load_module(label):
@@ -72,32 +103,60 @@ def load_module(label):
     return module
 
 
-def analyze_site(module, site, n_sweeps, return_sdf):
+def densetc_signal_bounds(spont):
+    if spont < 25:
+        return 0.001, 0.025
+    if spont < 50:
+        return 0.025, 0.050
+    if spont < 100:
+        return 0.050, 0.100
+    return 0.100, 0.150
+
+
+def get_signal_bounds(args, spont):
+    if args.signal_bounds == "densetc":
+        return densetc_signal_bounds(spont)
+    if args.signal_bounds == "cxx":
+        return 0.0, 0.1
+    if args.min_sig_bound is None or args.max_sig_bound is None:
+        raise ValueError(
+            "--signal-bounds custom requires --min-sig-bound and "
+            "--max-sig-bound")
+    return args.min_sig_bound, args.max_sig_bound
+
+
+def analyze_site(module, site, n_sweeps, return_sdf, args):
+    min_sig_bound, max_sig_bound = get_signal_bounds(
+        args, site["spont_firing_rate_hz"])
+    u_bound = args.u_bound if args.u_bound is not None else args.max_m
+
     return module.analyze_psth(
         np.array(site["psth"], dtype=np.int64),
         n_sweeps,
         site["spont_firing_rate_hz"],
-        max_t=250,
-        max_m=10,
-        lat_start=1,
-        lat_end=150,
-        l_bound=4,
-        u_bound=10,
+        max_t=args.max_t,
+        max_m=args.max_m,
+        lat_start=args.lat_start,
+        lat_end=args.lat_end,
+        l_bound=args.l_bound,
+        u_bound=u_bound,
+        min_sig_bound=min_sig_bound,
+        max_sig_bound=max_sig_bound,
         return_sdf=return_sdf,
     )
 
 
-def get_densetc_lats_from_result(site, result):
+def get_densetc_lats_from_result(site, result, lat_start):
     psth = np.array(site["psth"], dtype=np.int64)
     sdf = result["sdf"]
-    lats = np.nan_to_num(result["lats"][1:], nan=0.0, posinf=1.0,
+    lats = np.nan_to_num(result["lats"][lat_start:], nan=0.0, posinf=1.0,
                          neginf=0.0)
     max_prob = float(np.amax(lats))
     onset = np.where(0.15 <= lats)[0]
     if onset.any():
-        onset = int(onset[0] + 1)
+        onset = int(onset[0] + lat_start)
     else:
-        onset = int(np.argmax(lats) + 1)
+        onset = int(np.argmax(lats) + lat_start)
 
     total_prob = float(np.nan_to_num(result["total_prob"], nan=0.0,
                                      posinf=1.0, neginf=0.0))
@@ -131,31 +190,49 @@ def get_densetc_lats_from_result(site, result):
     return onset, peak, offset
 
 
-def check_latencies(module, sites, n_sweeps):
+def check_latencies(module, sites, n_sweeps, args):
     matches = 0
+    mismatches = []
+    component_matches = {"onset": 0, "peak": 0, "offset": 0}
+    abs_errors = {"onset": [], "peak": [], "offset": []}
     for site in sites:
-        result = analyze_site(module, site, n_sweeps, return_sdf=True)
-        got = get_densetc_lats_from_result(site, result)
+        result = analyze_site(module, site, n_sweeps, return_sdf=True,
+                              args=args)
+        got = get_densetc_lats_from_result(site, result, args.lat_start)
         expected = (site["onset_ms"], site["peak_ms"], site["offset_ms"])
+        for idx, key in enumerate(("onset", "peak", "offset")):
+            if got[idx] == expected[idx]:
+                component_matches[key] += 1
+            if got[idx] is not None and expected[idx] is not None:
+                abs_errors[key].append(abs(got[idx] - expected[idx]))
         if got == expected and np.isfinite(result["lats"]).all():
             matches += 1
-    return matches
+        else:
+            mismatches.append((site["number"], expected, got))
+    return matches, mismatches, component_matches, abs_errors
 
 
-def bench(module, sites, n_sweeps, return_sdf, repeats):
-    analyze_site(module, sites[0], n_sweeps, return_sdf)
+def mean(values):
+    if not values:
+        return float("nan")
+    return statistics.mean(values)
+
+
+def bench(module, sites, n_sweeps, return_sdf, repeats, args):
+    analyze_site(module, sites[0], n_sweeps, return_sdf, args)
     times = []
     for _ in range(repeats):
         start = time.perf_counter()
         for site in sites:
-            analyze_site(module, site, n_sweeps, return_sdf)
+            analyze_site(module, site, n_sweeps, return_sdf, args)
         times.append(time.perf_counter() - start)
     return times
 
 
 def main():
     args = parse_args()
-    sites, n_sweeps = load_demo_sites(args.demo_json)
+    sites, n_sweeps, analysis_id = load_demo_sites(args.demo_json,
+                                                   args.analysis)
     sites = sites[:args.sites]
     labels = ["worktree", *args.ref]
     modes = []
@@ -164,15 +241,41 @@ def main():
     if args.mode in ("both", "sdf"):
         modes.append(("sdf", True))
 
-    print(f"sites={len(sites)} repeats={args.repeats} n_sweeps={n_sweeps}")
+    run_desc = f"sites={len(sites)} n_sweeps={n_sweeps}"
+    if args.check_only:
+        run_desc += " check_only=True"
+    else:
+        run_desc += f" repeats={args.repeats}"
+    print(
+        f"analysis={args.analysis} analysis_id={analysis_id} {run_desc}")
     for label in labels:
         module = load_module(label)
         print(f"\n[{label}]")
         if not args.skip_latency_check:
-            matches = check_latencies(module, sites, n_sweeps)
+            matches, mismatches, component_matches, abs_errors = (
+                check_latencies(module, sites, n_sweeps, args)
+            )
             print(f"latency_matches={matches}/{len(sites)}")
+            print(
+                "component_matches="
+                f"onset:{component_matches['onset']}/{len(sites)} "
+                f"peak:{component_matches['peak']}/{len(sites)} "
+                f"offset:{component_matches['offset']}/{len(sites)}")
+            print(
+                "mean_abs_ms="
+                f"onset:{mean(abs_errors['onset']):.2f} "
+                f"peak:{mean(abs_errors['peak']):.2f} "
+                f"offset:{mean(abs_errors['offset']):.2f}")
+            if args.show_mismatches:
+                for number, expected, got in mismatches[:args.show_mismatches]:
+                    print(
+                        f"mismatch number={number} expected={expected} "
+                        f"got={got}")
+        if args.check_only:
+            continue
         for mode_label, return_sdf in modes:
-            times = bench(module, sites, n_sweeps, return_sdf, args.repeats)
+            times = bench(module, sites, n_sweeps, return_sdf, args.repeats,
+                          args)
             median = statistics.median(times)
             per_site = median / len(sites)
             rounded = ", ".join(f"{value:.3f}" for value in times)

--- a/src/bayesian_bins.py
+++ b/src/bayesian_bins.py
@@ -79,9 +79,12 @@ def nb_calc_m_priors(max_m, max_t, sigma, gamma):
 def nb_logsumexp(arr):
     return np.log(np.sum(np.exp(arr)))
 
-@nb.njit(fastmath=True, parallel=False)
+@nb.njit
 def nb_max_logsumexp(arr):
     max_val = np.max(arr)
+    if not np.isfinite(max_val):
+        return max_val
+
     return np.log(np.sum(np.exp(arr - max_val))) + max_val
 
 
@@ -370,7 +373,7 @@ def nb_calc_latency(big_e, m_priors, event_counts, num_sweeps, lat_start,
 def nb_para_calc_lats(big_e, m_priors, event_counts, num_sweeps, lat_start,
                       lat_end, max_m, max_t, sigma, gamma, l_bound, u_bound,
                       signal):
-    results = np.empty(max_t)
+    results = np.zeros(max_t)
     for lat_idx in nb.prange(lat_start, lat_end):
         results[lat_idx] = nb_calc_latency(big_e, m_priors, event_counts, 
                                            num_sweeps, lat_start, lat_end, 
@@ -615,6 +618,7 @@ def analyze_psth(psth, n_sweeps, spont=None, sigma=None, gamma=None,
     lats = nb_para_calc_lats(big_e, m_priors, event_counts, n_sweeps, 
                              lat_start, lat_end, max_m, max_t, sigma, gamma, 
                              l_bound, u_bound, signal)
+    lats[np.isnan(lats)] = 0
     # Random cases may have rounding errors but should be treated as 1 or 0
     lats[1 < lats] = 1
     lats[lats < 0] = 0

--- a/src/bayesian_bins.py
+++ b/src/bayesian_bins.py
@@ -569,9 +569,8 @@ def analyze_psth(psth, n_sweeps, spont=None, sigma=None, gamma=None,
     Arguments:
     psth: Your PSTH, of course, silly. A numpy array, assuming 1 bin / ms.
     n_sweeps: The number of spiketrains that make up the PSTH.
-    spont: Spontaneous level of activity. Must specify spont or sigma/gamma and
-      min/max_sig_bound. If only spont is specified, will try to estimate good
-      values for sigma/gamma and min/max_sig_bound based on empirical use.
+    spont: Spontaneous level of activity. Must specify spont or sigma/gamma.
+      If only spont is specified, sigma/gamma are estimated from spont.
       spont should be specified as Hz value, and be at least 1 Hz (lower values
       create a lot of false positives results, in my experience).
     max_t: PSTH window to search for a latency over
@@ -583,11 +582,9 @@ def analyze_psth(psth, n_sweeps, spont=None, sigma=None, gamma=None,
     sigma/gamma: Essentially determine predicted firing rates.
       Think sigma==spikes/ms, gamma==non-spikes/ms.
       sigma=1, gamma=1000 -> 1 Hz spontaneous
-    min/max_sig_bound: The boundaries for the optimizer.
-      These should be modified at major differences in spontaneous activity.
-      aka. PSTH with 10 Hz spont will not have same signal as one with 100 Hz.
-      Default values of 0.001 and 0.025 essentially look for signal between
-      1 and 25 Hz firing rates.
+    min/max_sig_bound: The boundaries for the signal separator optimizer.
+      Defaults to C++ original 0.0 and 0.1. Application-specific callers may pass
+      narrower ranges when they have validated domain-specific expectations.
     return_sdf: Return a Spike Density, or not.
       Takes a minute to do, but is vry nice.
     
@@ -613,23 +610,10 @@ def analyze_psth(psth, n_sweeps, spont=None, sigma=None, gamma=None,
     if not u_bound:
         u_bound = max_m
         
-    if not min_sig_bound or not max_sig_bound:
-        # Full on empirical, your results may vary
-        # May work same/better by doing spont +/-, but that requires testing...
-        # These values are based on categorically distinct spont levels from
-        # categorically distinct neural populations, not an optimum +/- search.
-        if spont < 25:
-            min_sig_bound = 0.001
-            max_sig_bound = 0.025
-        elif spont < 50:
-            min_sig_bound = 0.025
-            max_sig_bound = 0.050
-        elif spont < 100:
-            min_sig_bound = 0.050
-            max_sig_bound = 0.100
-        else:
-            min_sig_bound = 0.100
-            max_sig_bound = 0.150
+    if min_sig_bound is None:
+        min_sig_bound = 0.0
+    if max_sig_bound is None:
+        max_sig_bound = 0.1
         
     event_counts = psth.cumsum()
     sdf_interval_evidences = None

--- a/src/bayesian_bins.py
+++ b/src/bayesian_bins.py
@@ -7,7 +7,7 @@ if os.environ.get("ADS_ENABLE_SVML") == "1":
     binding.set_option('SVML', '-vector-library=SVML')
 
 import numpy as np
-from scipy.optimize import minimize_scalar
+from scipy.optimize import minimize, minimize_scalar
 import numba as nb
 import ctypes
 
@@ -549,10 +549,96 @@ def get_sdf(t_big_e, t_m_priors, t_interval_evidences, t_event_counts,
 
     return t_sdf
 
+
+def calc_total_evidence(psth, n_sweeps, sigma, gamma, max_t=None, max_m=10):
+    """Return log P(D), assuming a uniform prior over M."""
+    if max_t is None:
+        max_t = len(psth)
+
+    event_counts = psth.cumsum()
+    interval_evidences = nb_precompute_interval_evidences(
+        event_counts, n_sweeps, max_t, sigma, gamma)
+    m_priors = nb_calc_m_priors(max_m, max_t, sigma, gamma)
+    big_e = nb_calc_big_e(m_priors, interval_evidences, max_m, max_t)
+    return nb_max_logsumexp(big_e) - np.log(max_m + 1)
+
+
+def fit_prior_exponents(psth, n_sweeps, max_t=None, max_m=10,
+                        initial_sigma=1.0, initial_gamma=32.0,
+                        shape_f=2.0, scale_f=0.030,
+                        shape_g=2.0, scale_g=1.0,
+                        sigma_bounds=(0.001, 300.0),
+                        gamma_bounds=(1.0, 300.0),
+                        maxiter=200, xatol=1e-3, fatol=1e-3):
+    """
+    Fit beta prior exponents using the optional original-C++ simplex objective.
+
+    C++ names these values efire and egap. In this module, sigma corresponds to
+    efire and gamma corresponds to egap.
+    """
+    if max_t is None:
+        max_t = len(psth)
+
+    psth = np.asarray(psth)
+    initial = np.array([
+        np.clip(initial_gamma, *gamma_bounds),
+        np.clip(initial_sigma, *sigma_bounds),
+    ], dtype=np.float64)
+
+    def objective(params):
+        gamma, sigma = params
+        if not (gamma_bounds[0] <= gamma <= gamma_bounds[1]):
+            return np.inf
+        if not (sigma_bounds[0] <= sigma <= sigma_bounds[1]):
+            return np.inf
+
+        total_evidence = calc_total_evidence(
+            psth, n_sweeps, sigma, gamma, max_t=max_t, max_m=max_m)
+        firing_prior = sigma / (gamma + sigma) / scale_f
+        magnitude_prior = 0.5 * (sigma * sigma + gamma * gamma) / scale_g
+        if firing_prior <= 0 or magnitude_prior <= 0:
+            return np.inf
+
+        return (
+            -total_evidence
+            - (shape_f - 1.0) * np.log(firing_prior)
+            + firing_prior
+            - (shape_g - 1.0) * np.log(magnitude_prior)
+            + magnitude_prior
+        )
+
+    result = minimize(
+        objective,
+        initial,
+        method="Nelder-Mead",
+        options={"maxiter": maxiter, "xatol": xatol, "fatol": fatol},
+    )
+    gamma, sigma = result.x
+    gamma = float(np.clip(gamma, *gamma_bounds))
+    sigma = float(np.clip(sigma, *sigma_bounds))
+    firing_prob = sigma / (sigma + gamma)
+    firing_sd = np.sqrt(gamma / (gamma + sigma + 1) / (gamma + sigma) *
+                        firing_prob)
+
+    return {
+        "sigma": sigma,
+        "gamma": gamma,
+        "firing_prob": float(firing_prob),
+        "firing_sd": float(firing_sd),
+        "total_evidence": float(calc_total_evidence(
+            psth, n_sweeps, sigma, gamma, max_t=max_t, max_m=max_m)),
+        "objective": float(objective((gamma, sigma))),
+        "success": bool(result.success),
+        "message": result.message,
+        "nit": result.nit,
+        "nfev": result.nfev,
+    }
+
+
 def analyze_psth(psth, n_sweeps, spont=None, sigma=None, gamma=None, 
                  max_t=None, max_m=10, lat_start=1, lat_end=None, l_bound=1,
                  u_bound=None, min_sig_bound=None, max_sig_bound=None, 
-                 return_sdf=True):
+                 return_sdf=True, fit_priors=False, prior_fit_options=None):
     """
     Main function to analyze a given PSTH.
     Returns onset latency and optionally an SDF.
@@ -587,6 +673,9 @@ def analyze_psth(psth, n_sweeps, spont=None, sigma=None, gamma=None,
       narrower ranges when they have validated domain-specific expectations.
     return_sdf: Return a Spike Density, or not.
       Takes a minute to do, but is vry nice.
+    fit_priors: Fit sigma/gamma with the optional C++ simplex-style objective
+      before latency/SDF analysis.
+    prior_fit_options: Dict of keyword arguments passed to fit_prior_exponents.
     
     
     """
@@ -614,6 +703,16 @@ def analyze_psth(psth, n_sweeps, spont=None, sigma=None, gamma=None,
         min_sig_bound = 0.0
     if max_sig_bound is None:
         max_sig_bound = 0.1
+
+    prior_fit = None
+    if fit_priors:
+        options = {} if prior_fit_options is None else dict(prior_fit_options)
+        options.setdefault("initial_sigma", sigma)
+        options.setdefault("initial_gamma", gamma)
+        prior_fit = fit_prior_exponents(
+            psth, n_sweeps, max_t=max_t, max_m=max_m, **options)
+        sigma = prior_fit["sigma"]
+        gamma = prior_fit["gamma"]
         
     event_counts = psth.cumsum()
     sdf_interval_evidences = None
@@ -676,6 +775,7 @@ def analyze_psth(psth, n_sweeps, spont=None, sigma=None, gamma=None,
               "sdf": sdf,
               "m_priors": m_priors,
               "sigma": sigma,
-              "gamma": gamma}
+              "gamma": gamma,
+              "prior_fit": prior_fit}
     
     return result

--- a/src/bayesian_bins.py
+++ b/src/bayesian_bins.py
@@ -110,6 +110,28 @@ def nb_precompute_interval_evidences(event_counts, num_sweeps, max_t, sigma,
     return interval_evidences
 
 
+@nb.njit(nogil=True, parallel=True)
+def nb_precompute_signal_logs(event_counts, num_sweeps, max_t, sigma, gamma,
+                              signal):
+    below_logs = np.zeros((max_t, max_t))
+    above_logs = np.zeros((max_t, max_t))
+
+    for start_idx in nb.prange(max_t):
+        if start_idx == 0:
+            prev_events = 0
+        else:
+            prev_events = event_counts[start_idx - 1]
+
+        for end_idx in range(start_idx, max_t):
+            events = event_counts[end_idx] - prev_events
+            gaps = num_sweeps*(end_idx - start_idx + 1) - events
+            below_prob = nb_betainc(events + sigma, gaps + gamma, signal)
+            below_logs[start_idx, end_idx] = np.log(below_prob)
+            above_logs[start_idx, end_idx] = np.log(1 - below_prob)
+
+    return below_logs, above_logs
+
+
 # Big E
 @nb.jit
 def nb_big_e_k_func(sub_e, m, interval_evidences, length, max_t):
@@ -182,9 +204,9 @@ def nb_calc_big_e(m_priors, interval_evidences, max_m, max_t):
 # Calculate m_latsum for signal probability estimation
 # (use with function optimizer like scipy minimize_scalar)
 @nb.njit(nogil=True, fastmath=True)
-def nb_calc_m_latsum(big_e, m_priors, interval_evidences, event_counts,
-                     num_sweeps, lat_start, lat_end, max_m, max_t, sigma,
-                     gamma, l_bound, u_bound, signal):
+def nb_calc_m_latsum(big_e, m_priors, interval_evidences, signal_below_logs,
+                     signal_above_logs, lat_start, lat_end, max_m, max_t,
+                     l_bound, u_bound):
 
     m_latsum = np.zeros(max_m)
     lat_sub_e = np.zeros(max_t)
@@ -197,10 +219,8 @@ def nb_calc_m_latsum(big_e, m_priors, interval_evidences, event_counts,
     passed_l_bound = l_bound
     
     for k_end in nb.prange(max_t):
-        events = event_counts[k_end]
-        gaps = num_sweeps*(k_end+1) - events
-        lat_sub_e[k_end] = interval_evidences[0, k_end] + \
-            np.log(nb_betainc((events + sigma), (gaps + gamma), signal))
+        lat_sub_e[k_end] = (
+            interval_evidences[0, k_end] + signal_below_logs[0, k_end])
             
     lat_sub_e_initial = lat_sub_e.copy()
     
@@ -221,9 +241,6 @@ def nb_calc_m_latsum(big_e, m_priors, interval_evidences, event_counts,
                     continue
                 
                 for r_idx in np.arange(sub_m, k_idx):
-                    events = event_counts[k_idx] - event_counts[r_idx]
-                    gaps = num_sweeps*(k_idx - r_idx) - events
-    
                     if sub_m > m:
                         if lat_sub_e[r_idx] == 0:
                             continue
@@ -238,16 +255,14 @@ def nb_calc_m_latsum(big_e, m_priors, interval_evidences, event_counts,
                             running_val[r_idx] = (
                                 lat_sub_e[r_idx] +
                                 interval_evidences[r_idx + 1, k_idx] +
-                                np.log(nb_betainc(
-                                    events + sigma, gaps + gamma, signal)))
+                                signal_below_logs[r_idx + 1, k_idx])
                     elif (r_idx < lat_start) or (r_idx > lat_end):
                         continue
                     else:
                         running_val[r_idx] = (
                             lat_sub_e[r_idx] +
                             interval_evidences[r_idx + 1, k_idx] +
-                            np.log(1 - nb_betainc(
-                                events + sigma, gaps + gamma, signal)))
+                            signal_above_logs[r_idx + 1, k_idx])
                             
                 # running_val window to sum over changes depending on 
                 # sub_m, k, lat_start, and lat_end (Must window correctly, 
@@ -298,18 +313,16 @@ def nb_calc_m_latsum(big_e, m_priors, interval_evidences, event_counts,
 
 # Latency
 @nb.njit(nogil=True, fastmath=True)
-def nb_calc_latency(big_e, m_priors, interval_evidences, event_counts,
-                    num_sweeps, lat_start, lat_end, max_m, max_t, sigma,
-                    gamma, l_bound, u_bound, signal, lat_idx):
+def nb_calc_latency(big_e, m_priors, interval_evidences, signal_below_logs,
+                    signal_above_logs, lat_start, lat_end, max_m, max_t,
+                    l_bound, u_bound, lat_idx):
     
     lat_sub_e = np.zeros(max_t)
     running_val = np.zeros(max_t)
     
     for k_end in nb.prange(lat_idx):
-        events = event_counts[k_end]
-        gaps = num_sweeps*(k_end+1) - events
-        lat_sub_e[k_end] = interval_evidences[0, k_end] + \
-            np.log(nb_betainc((events + sigma), (gaps + gamma), signal))
+        lat_sub_e[k_end] = (
+            interval_evidences[0, k_end] + signal_below_logs[0, k_end])
     
     lat_big_e = m_priors.copy()
     lat_big_e[0] = lat_sub_e[max_t-1] + m_priors[0]
@@ -328,9 +341,6 @@ def nb_calc_latency(big_e, m_priors, interval_evidences, event_counts,
                 continue
             
             for r_idx in np.arange(m, k_idx):
-                events = event_counts[k_idx] - event_counts[r_idx]
-                gaps = num_sweeps*(k_idx - r_idx) - events
-                
                 if r_idx >= lat_idx:
                     if lat_sub_e[r_idx] == 0:
                         continue
@@ -345,8 +355,7 @@ def nb_calc_latency(big_e, m_priors, interval_evidences, event_counts,
                         running_val[r_idx] = (
                             lat_sub_e[r_idx] +
                             interval_evidences[r_idx + 1, k_idx] +
-                            np.log(nb_betainc(
-                                events + sigma, gaps + gamma, signal)))
+                            signal_below_logs[r_idx + 1, k_idx])
                 elif ((r_idx+1)==lat_idx):
                     if lat_sub_e[r_idx] == 0:
                         continue
@@ -354,8 +363,7 @@ def nb_calc_latency(big_e, m_priors, interval_evidences, event_counts,
                         running_val[r_idx] = (
                             lat_sub_e[r_idx] +
                             interval_evidences[r_idx + 1, k_idx] +
-                            np.log(1 - nb_betainc(
-                                events + sigma, gaps + gamma, signal)))
+                            signal_above_logs[r_idx + 1, k_idx])
                 else:
                     continue
             
@@ -388,15 +396,15 @@ def nb_calc_latency(big_e, m_priors, interval_evidences, event_counts,
 
 
 @nb.njit(nogil=True, parallel=True)
-def nb_para_calc_lats(big_e, m_priors, interval_evidences, event_counts,
-                      num_sweeps, lat_start, lat_end, max_m, max_t, sigma,
-                      gamma, l_bound, u_bound, signal):
+def nb_para_calc_lats(big_e, m_priors, interval_evidences, signal_below_logs,
+                      signal_above_logs, lat_start, lat_end, max_m, max_t,
+                      l_bound, u_bound):
     results = np.zeros(max_t)
     for lat_idx in nb.prange(lat_start, lat_end):
         results[lat_idx] = nb_calc_latency(
-            big_e, m_priors, interval_evidences, event_counts, num_sweeps,
-            lat_start, lat_end, max_m, max_t, sigma, gamma, l_bound, u_bound,
-            signal, lat_idx)
+            big_e, m_priors, interval_evidences, signal_below_logs,
+            signal_above_logs, lat_start, lat_end, max_m, max_t, l_bound,
+            u_bound, lat_idx)
         
     return results
 
@@ -474,10 +482,9 @@ def calc_sdf_sub_e(sdf_idx, interval_evidences, event_counts, num_sweeps,
     sdf_sub_e = np.zeros(max_t)
     
     for k_end in nb.prange(max_t):
-        events = event_counts[k_end]
-        gaps = num_sweeps*(k_end+1) - events
-        
         if sdf_idx <= k_end:
+            events = event_counts[k_end]
+            gaps = num_sweeps*(k_end+1) - events
             sdf_sub_e[k_end] = interval_evidences[0, k_end] + \
                 np.log(sigma + events) - np.log(sigma + gamma + events + gaps)
         else:
@@ -624,16 +631,28 @@ def analyze_psth(psth, n_sweeps, spont=None, sigma=None, gamma=None,
             min_sig_bound = 0.100
             max_sig_bound = 0.150
         
-    event_counts = psth.cumsum()    
+    event_counts = psth.cumsum()
+    sdf_interval_evidences = None
+    if return_sdf and len(psth) >= max_t:
+        sdf_interval_evidences = nb_precompute_interval_evidences(
+            event_counts, n_sweeps, len(psth), sigma, gamma)
+        interval_evidences = sdf_interval_evidences
+    else:
+        interval_evidences = nb_precompute_interval_evidences(
+            event_counts, n_sweeps, max_t, sigma, gamma)
+
     m_priors = nb_calc_m_priors(max_m, max_t, sigma, gamma)
-    interval_evidences = nb_precompute_interval_evidences(
-        event_counts, n_sweeps, max_t, sigma, gamma)
     big_e = nb_calc_big_e(m_priors, interval_evidences, max_m, max_t)
 
     # func returns 1-p, since scipy uses a minimizer for optimization
-    func = lambda sig: nb_calc_m_latsum(
-        big_e, m_priors, interval_evidences, event_counts, n_sweeps, lat_start,
-        lat_end, max_m, max_t, sigma, gamma, l_bound, u_bound, sig)
+    def func(sig):
+        signal_below_logs, signal_above_logs = nb_precompute_signal_logs(
+            event_counts, n_sweeps, max_t, sigma, gamma, sig)
+        return nb_calc_m_latsum(
+            big_e, m_priors, interval_evidences, signal_below_logs,
+            signal_above_logs, lat_start, lat_end, max_m, max_t, l_bound,
+            u_bound)
+
     result = minimize_scalar(func, bounds=(min_sig_bound, max_sig_bound),
                              method="bounded", options={"maxiter": 30})
     # Probability that neural response exists at given signal level
@@ -641,9 +660,11 @@ def analyze_psth(psth, n_sweeps, spont=None, sigma=None, gamma=None,
     total_prob = 1 - result.fun
     
     # Array of len max_t with probs of latency existing for each time idx
+    signal_below_logs, signal_above_logs = nb_precompute_signal_logs(
+        event_counts, n_sweeps, max_t, sigma, gamma, signal)
     lats = nb_para_calc_lats(
-        big_e, m_priors, interval_evidences, event_counts, n_sweeps, lat_start,
-        lat_end, max_m, max_t, sigma, gamma, l_bound, u_bound, signal)
+        big_e, m_priors, interval_evidences, signal_below_logs,
+        signal_above_logs, lat_start, lat_end, max_m, max_t, l_bound, u_bound)
     lats[np.isnan(lats)] = 0
     # Random cases may have rounding errors but should be treated as 1 or 0
     lats[1 < lats] = 1
@@ -654,8 +675,11 @@ def analyze_psth(psth, n_sweeps, spont=None, sigma=None, gamma=None,
         # Must re-calculate some variables to use entire PSTH sweep length
         max_t = len(psth)
         m_priors = nb_calc_m_priors(max_m, max_t, sigma, gamma)
-        interval_evidences = nb_precompute_interval_evidences(
-            event_counts, n_sweeps, max_t, sigma, gamma)
+        if sdf_interval_evidences is None:
+            interval_evidences = nb_precompute_interval_evidences(
+                event_counts, n_sweeps, max_t, sigma, gamma)
+        else:
+            interval_evidences = sdf_interval_evidences
         big_e = nb_calc_big_e(m_priors, interval_evidences, max_m, max_t)
         sdf = get_sdf(big_e, m_priors, interval_evidences, event_counts,
                       n_sweeps, max_m, max_t, sigma, gamma, l_bound, u_bound)

--- a/src/bayesian_bins.py
+++ b/src/bayesian_bins.py
@@ -88,10 +88,31 @@ def nb_max_logsumexp(arr):
     return np.log(np.sum(np.exp(arr - max_val))) + max_val
 
 
+@nb.njit(nogil=True, parallel=True)
+def nb_precompute_interval_evidences(event_counts, num_sweeps, max_t, sigma,
+                                     gamma):
+    # This mirrors the original C++ cache: each DP pass reuses the same
+    # interval beta evidence values many times.
+    interval_evidences = np.zeros((max_t, max_t))
+
+    for start_idx in nb.prange(max_t):
+        if start_idx == 0:
+            prev_events = 0
+        else:
+            prev_events = event_counts[start_idx - 1]
+
+        for end_idx in range(start_idx, max_t):
+            events = event_counts[end_idx] - prev_events
+            gaps = num_sweeps*(end_idx - start_idx + 1) - events
+            interval_evidences[start_idx, end_idx] = nb_betaln(
+                events + sigma, gaps + gamma)
+
+    return interval_evidences
+
+
 # Big E
 @nb.jit
-def nb_big_e_k_func(sub_e, m, event_counts, num_sweeps, sigma, gamma, length, 
-                    max_t):
+def nb_big_e_k_func(sub_e, m, interval_evidences, length, max_t):
     """
     Big E
     Define k-loop func
@@ -109,15 +130,7 @@ def nb_big_e_k_func(sub_e, m, event_counts, num_sweeps, sigma, gamma, length,
         else:
             # All other cases proceed to their r-funcs
             r_idx = np.arange(m, k_idx)
-            events = event_counts[k_idx] - event_counts[r_idx]
-            gaps = num_sweeps*(k_idx - r_idx) - events
-            
-            # Calculate 'running_val'
-            # Using vec betaln so it can have arrays instead of writing
-            # another loop, but this may be inefficient or slower than 
-            # explicitly using JIT + for loop
-            running_val = sub_e[r_idx] + vec_betaln((events + sigma), 
-                                                    (gaps + gamma))
+            running_val = sub_e[r_idx] + interval_evidences[r_idx + 1, k_idx]
 
             new_sub_e[k_idx] = nb_max_logsumexp(running_val)
 
@@ -126,7 +139,7 @@ def nb_big_e_k_func(sub_e, m, event_counts, num_sweeps, sigma, gamma, length,
 
 
 @nb.jit
-def calc_sub_e_parallel(event_counts, num_sweeps, max_t, sigma, gamma):
+def calc_sub_e_parallel(interval_evidences, max_t):
     """
     JITing initial big E sub_e calculation just to be explicit about
     parallelization. I don't know if numba would be upset about it or not,
@@ -137,20 +150,16 @@ def calc_sub_e_parallel(event_counts, num_sweeps, max_t, sigma, gamma):
     sub_e = np.zeros(max_t)
     
     for k_end in nb.prange(max_t):
-        events = event_counts[k_end]
-        gaps = num_sweeps*(k_end+1) - events
-        
-        sub_e[k_end] = nb_betaln((events + sigma), (gaps + gamma))
+        sub_e[k_end] = interval_evidences[0, k_end]
                     
     return sub_e
 
 
 # Big E main function call
 @nb.jit
-def nb_calc_big_e(m_priors, event_counts, num_sweeps, max_m, max_t, sigma,
-                  gamma):
+def nb_calc_big_e(m_priors, interval_evidences, max_m, max_t):
 
-    sub_e = calc_sub_e_parallel(event_counts, num_sweeps, max_t, sigma, gamma)
+    sub_e = calc_sub_e_parallel(interval_evidences, max_t)
     big_e = np.zeros(max_m + 1)
     big_e[0] = sub_e[-1] + m_priors[0]
     
@@ -162,8 +171,7 @@ def nb_calc_big_e(m_priors, event_counts, num_sweeps, max_m, max_t, sigma,
             length = m
             
         # Now k-loop!
-        sub_e = nb_big_e_k_func(sub_e, m, event_counts, num_sweeps, sigma, 
-                                gamma, length, max_t)
+        sub_e = nb_big_e_k_func(sub_e, m, interval_evidences, length, max_t)
 
         # Finish m-iteration with big_e update
         big_e[m+1] = sub_e[-1] + m_priors[m+1]
@@ -174,9 +182,9 @@ def nb_calc_big_e(m_priors, event_counts, num_sweeps, max_m, max_t, sigma,
 # Calculate m_latsum for signal probability estimation
 # (use with function optimizer like scipy minimize_scalar)
 @nb.njit(nogil=True, fastmath=True)
-def nb_calc_m_latsum(big_e, m_priors, event_counts, num_sweeps, lat_start, 
-                     lat_end, max_m, max_t, sigma, gamma, l_bound, u_bound, 
-                     signal):
+def nb_calc_m_latsum(big_e, m_priors, interval_evidences, event_counts,
+                     num_sweeps, lat_start, lat_end, max_m, max_t, sigma,
+                     gamma, l_bound, u_bound, signal):
 
     m_latsum = np.zeros(max_m)
     lat_sub_e = np.zeros(max_t)
@@ -191,7 +199,7 @@ def nb_calc_m_latsum(big_e, m_priors, event_counts, num_sweeps, lat_start,
     for k_end in nb.prange(max_t):
         events = event_counts[k_end]
         gaps = num_sweeps*(k_end+1) - events
-        lat_sub_e[k_end] = vec_betaln((events + sigma), (gaps + gamma)) + \
+        lat_sub_e[k_end] = interval_evidences[0, k_end] + \
             np.log(nb_betainc((events + sigma), (gaps + gamma), signal))
             
     lat_sub_e_initial = lat_sub_e.copy()
@@ -220,21 +228,26 @@ def nb_calc_m_latsum(big_e, m_priors, event_counts, num_sweeps, lat_start,
                         if lat_sub_e[r_idx] == 0:
                             continue
                         else:
-                            running_val[r_idx] = lat_sub_e[r_idx] + vec_betaln(
-                            (events + sigma), (gaps + gamma))
+                            running_val[r_idx] = (
+                                lat_sub_e[r_idx] +
+                                interval_evidences[r_idx + 1, k_idx])
                     elif sub_m < m:
                         if lat_sub_e[r_idx] == 0:
                             continue
                         else:
-                            running_val[r_idx] = lat_sub_e[r_idx] + vec_betaln(
-                            (events + sigma), (gaps + gamma)) + np.log(
-                                nb_betainc(events+sigma, gaps+gamma, signal)) 
+                            running_val[r_idx] = (
+                                lat_sub_e[r_idx] +
+                                interval_evidences[r_idx + 1, k_idx] +
+                                np.log(nb_betainc(
+                                    events + sigma, gaps + gamma, signal)))
                     elif (r_idx < lat_start) or (r_idx > lat_end):
                         continue
                     else:
-                        running_val[r_idx] = lat_sub_e[r_idx] + vec_betaln(
-                            (events + sigma), (gaps + gamma)) + np.log(1 - \
-                                nb_betainc(events+sigma, gaps+gamma, signal))
+                        running_val[r_idx] = (
+                            lat_sub_e[r_idx] +
+                            interval_evidences[r_idx + 1, k_idx] +
+                            np.log(1 - nb_betainc(
+                                events + sigma, gaps + gamma, signal)))
                             
                 # running_val window to sum over changes depending on 
                 # sub_m, k, lat_start, and lat_end (Must window correctly, 
@@ -285,9 +298,9 @@ def nb_calc_m_latsum(big_e, m_priors, event_counts, num_sweeps, lat_start,
 
 # Latency
 @nb.njit(nogil=True, fastmath=True)
-def nb_calc_latency(big_e, m_priors, event_counts, num_sweeps, lat_start, 
-                    lat_end, max_m, max_t, sigma, gamma, l_bound, u_bound, 
-                    signal, lat_idx):
+def nb_calc_latency(big_e, m_priors, interval_evidences, event_counts,
+                    num_sweeps, lat_start, lat_end, max_m, max_t, sigma,
+                    gamma, l_bound, u_bound, signal, lat_idx):
     
     lat_sub_e = np.zeros(max_t)
     running_val = np.zeros(max_t)
@@ -295,7 +308,7 @@ def nb_calc_latency(big_e, m_priors, event_counts, num_sweeps, lat_start,
     for k_end in nb.prange(lat_idx):
         events = event_counts[k_end]
         gaps = num_sweeps*(k_end+1) - events
-        lat_sub_e[k_end] = vec_betaln((events + sigma), (gaps + gamma)) + \
+        lat_sub_e[k_end] = interval_evidences[0, k_end] + \
             np.log(nb_betainc((events + sigma), (gaps + gamma), signal))
     
     lat_big_e = m_priors.copy()
@@ -322,22 +335,27 @@ def nb_calc_latency(big_e, m_priors, event_counts, num_sweeps, lat_start,
                     if lat_sub_e[r_idx] == 0:
                         continue
                     else:
-                        running_val[r_idx] = lat_sub_e[r_idx] + vec_betaln(
-                            (events + sigma), (gaps + gamma))
+                        running_val[r_idx] = (
+                            lat_sub_e[r_idx] +
+                            interval_evidences[r_idx + 1, k_idx])
                 elif k_idx < lat_idx:
                     if lat_sub_e[r_idx] == 0:
                         continue
                     else:
-                        running_val[r_idx] =  lat_sub_e[r_idx] + vec_betaln(
-                            (events + sigma), (gaps + gamma)) + np.log(
-                                nb_betainc(events+sigma, gaps+gamma, signal)) 
+                        running_val[r_idx] = (
+                            lat_sub_e[r_idx] +
+                            interval_evidences[r_idx + 1, k_idx] +
+                            np.log(nb_betainc(
+                                events + sigma, gaps + gamma, signal)))
                 elif ((r_idx+1)==lat_idx):
                     if lat_sub_e[r_idx] == 0:
                         continue
                     else:
-                        running_val[r_idx] =  lat_sub_e[r_idx] + vec_betaln(
-                            (events + sigma), (gaps + gamma)) + np.log(1 - \
-                                nb_betainc(events+sigma, gaps+gamma, signal))
+                        running_val[r_idx] = (
+                            lat_sub_e[r_idx] +
+                            interval_evidences[r_idx + 1, k_idx] +
+                            np.log(1 - nb_betainc(
+                                events + sigma, gaps + gamma, signal)))
                 else:
                     continue
             
@@ -370,15 +388,15 @@ def nb_calc_latency(big_e, m_priors, event_counts, num_sweeps, lat_start,
 
 
 @nb.njit(nogil=True, parallel=True)
-def nb_para_calc_lats(big_e, m_priors, event_counts, num_sweeps, lat_start,
-                      lat_end, max_m, max_t, sigma, gamma, l_bound, u_bound,
-                      signal):
+def nb_para_calc_lats(big_e, m_priors, interval_evidences, event_counts,
+                      num_sweeps, lat_start, lat_end, max_m, max_t, sigma,
+                      gamma, l_bound, u_bound, signal):
     results = np.zeros(max_t)
     for lat_idx in nb.prange(lat_start, lat_end):
-        results[lat_idx] = nb_calc_latency(big_e, m_priors, event_counts, 
-                                           num_sweeps, lat_start, lat_end, 
-                                           max_m, max_t, sigma, gamma, l_bound, 
-                                           u_bound, signal, lat_idx)
+        results[lat_idx] = nb_calc_latency(
+            big_e, m_priors, interval_evidences, event_counts, num_sweeps,
+            lat_start, lat_end, max_m, max_t, sigma, gamma, l_bound, u_bound,
+            signal, lat_idx)
         
     return results
 
@@ -386,7 +404,8 @@ def nb_para_calc_lats(big_e, m_priors, event_counts, num_sweeps, lat_start,
 
 # SDF
 @nb.vectorize(target='cpu')
-def nb_cython_r_calc(sub_e_val, r_idx, sdf_idx, k, events, gaps, sigma, gamma):
+def nb_cython_r_calc(sub_e_val, r_idx, sdf_idx, k, events, gaps,
+                     interval_evidence, sigma, gamma):
     """
     Define r-loop func.
     Currently this is a 'vectorized u-func', in order to avoid using for loops
@@ -400,16 +419,16 @@ def nb_cython_r_calc(sub_e_val, r_idx, sdf_idx, k, events, gaps, sigma, gamma):
         return 0
 
     if r_idx < sdf_idx <= k:
-        return sub_e_val + vec_betaln((events + sigma), (gaps + gamma)) + \
+        return sub_e_val + interval_evidence + \
             np.log(sigma + events) - np.log(sigma + gamma + events + gaps)
     
     else:
-        return sub_e_val + vec_betaln((events + sigma), (gaps + gamma))
+        return sub_e_val + interval_evidence
 
 
 @nb.njit(nogil=True, fastmath=True)
-def nb_k_func(sdf_sub_e, sdf_idx, sub_m, event_counts, num_sweeps, sigma, 
-              gamma, length, max_t):
+def nb_k_func(sdf_sub_e, sdf_idx, sub_m, interval_evidences, event_counts,
+              num_sweeps, sigma, gamma, length, max_t):
     """
     Define k-loop func.
     Literally just run the calc r function for each value of k in t_k_idx now.
@@ -431,7 +450,10 @@ def nb_k_func(sdf_sub_e, sdf_idx, sub_m, event_counts, num_sweeps, sigma,
             
             # Vectorized r-loop
             running_val = nb_cython_r_calc(sdf_sub_e[r_idx], r_idx, sdf_idx, 
-                                           k_idx, events, gaps, sigma, gamma)
+                                           k_idx, events, gaps,
+                                           interval_evidences[r_idx + 1,
+                                                              k_idx],
+                                           sigma, gamma)
             
             # logsumexp running_val
             running_val_max = np.max(running_val)
@@ -442,7 +464,8 @@ def nb_k_func(sdf_sub_e, sdf_idx, sub_m, event_counts, num_sweeps, sigma,
 
 
 @nb.njit(nogil=True, fastmath=True)
-def calc_sdf_sub_e(sdf_idx, event_counts, num_sweeps, max_t, sigma, gamma):
+def calc_sdf_sub_e(sdf_idx, interval_evidences, event_counts, num_sweeps,
+                   max_t, sigma, gamma):
     """
     SDF sub_E initial calculation JIT. Only called once per SDF, but there are
     a lot of SDF calls, so little differences add up.
@@ -455,20 +478,20 @@ def calc_sdf_sub_e(sdf_idx, event_counts, num_sweeps, max_t, sigma, gamma):
         gaps = num_sweeps*(k_end+1) - events
         
         if sdf_idx <= k_end:
-            sdf_sub_e[k_end] = vec_betaln((events + sigma), (gaps + gamma)) + \
+            sdf_sub_e[k_end] = interval_evidences[0, k_end] + \
                 np.log(sigma + events) - np.log(sigma + gamma + events + gaps)
         else:
-            sdf_sub_e[k_end] = vec_betaln((events + sigma), (gaps + gamma))
+            sdf_sub_e[k_end] = interval_evidences[0, k_end]
                     
     return sdf_sub_e
 
 
 # Defining SDF main function call for each SDF index.
 @nb.njit
-def nb_calc_sdf(big_e, m_priors, event_counts, num_sweeps, max_m, max_t, sigma,
-                gamma, l_bound, u_bound, sdf_idx):
-    sdf_sub_e = calc_sdf_sub_e(sdf_idx, event_counts, num_sweeps, max_t, sigma,
-                               gamma)
+def nb_calc_sdf(big_e, m_priors, interval_evidences, event_counts, num_sweeps,
+                max_m, max_t, sigma, gamma, l_bound, u_bound, sdf_idx):
+    sdf_sub_e = calc_sdf_sub_e(sdf_idx, interval_evidences, event_counts,
+                               num_sweeps, max_t, sigma, gamma)
     sdf_big_e = np.zeros(max_m + 1)
     sdf_big_e[0] = sdf_sub_e[-1] + m_priors[0]
     
@@ -484,8 +507,9 @@ def nb_calc_sdf(big_e, m_priors, event_counts, num_sweeps, max_m, max_t, sigma,
         # it is supposed to (depending on the value of k within the 'k-loop'). 
         # The returned 'new' sdf_sub_e should therefore still have the correct
         # sizing.
-        sdf_sub_e = nb_k_func(sdf_sub_e, sdf_idx, sub_m, event_counts, 
-                              num_sweeps, sigma, gamma, length, max_t)
+        sdf_sub_e = nb_k_func(sdf_sub_e, sdf_idx, sub_m, interval_evidences,
+                              event_counts, num_sweeps, sigma, gamma, length,
+                              max_t)
         sdf_big_e[sub_m+1] = sdf_sub_e[-1] + m_priors[sub_m+1]
         
     sdf_big_e_val_max = np.max(sdf_big_e[l_bound:(u_bound+1)])
@@ -501,8 +525,9 @@ def nb_calc_sdf(big_e, m_priors, event_counts, num_sweeps, max_m, max_t, sigma,
 
 
 @nb.njit(nogil=True, parallel=True)
-def get_sdf(t_big_e, t_m_priors, t_event_counts, t_num_sweeps, t_max_m, 
-            t_max_t, t_sigma, t_gamma, t_l_bound, t_u_bound):
+def get_sdf(t_big_e, t_m_priors, t_interval_evidences, t_event_counts,
+            t_num_sweeps, t_max_m, t_max_t, t_sigma, t_gamma, t_l_bound,
+            t_u_bound):
     """
     Simple JIT for the for loop involved in calculating an entire SDF curve
     Don't know if this is really faster or not yet, but it doesn't hurt and it
@@ -510,9 +535,10 @@ def get_sdf(t_big_e, t_m_priors, t_event_counts, t_num_sweeps, t_max_m,
     """
     t_sdf = np.zeros(t_max_t)
     for sdf_idx in nb.prange(t_max_t):
-        t_sdf[sdf_idx] = nb_calc_sdf(t_big_e, t_m_priors, t_event_counts,
-                                     t_num_sweeps, t_max_m, t_max_t, t_sigma,
-                                     t_gamma, t_l_bound, t_u_bound, sdf_idx)
+        t_sdf[sdf_idx] = nb_calc_sdf(
+            t_big_e, t_m_priors, t_interval_evidences, t_event_counts,
+            t_num_sweeps, t_max_m, t_max_t, t_sigma, t_gamma, t_l_bound,
+            t_u_bound, sdf_idx)
 
     return t_sdf
 
@@ -600,14 +626,14 @@ def analyze_psth(psth, n_sweeps, spont=None, sigma=None, gamma=None,
         
     event_counts = psth.cumsum()    
     m_priors = nb_calc_m_priors(max_m, max_t, sigma, gamma)
-    big_e = nb_calc_big_e(m_priors, event_counts, n_sweeps, max_m, max_t, 
-                          sigma, gamma)
+    interval_evidences = nb_precompute_interval_evidences(
+        event_counts, n_sweeps, max_t, sigma, gamma)
+    big_e = nb_calc_big_e(m_priors, interval_evidences, max_m, max_t)
 
     # func returns 1-p, since scipy uses a minimizer for optimization
-    func = lambda sig: nb_calc_m_latsum(big_e, m_priors, event_counts,
-                                        n_sweeps, lat_start, lat_end, max_m,
-                                        max_t, sigma, gamma, l_bound, u_bound,
-                                        sig)
+    func = lambda sig: nb_calc_m_latsum(
+        big_e, m_priors, interval_evidences, event_counts, n_sweeps, lat_start,
+        lat_end, max_m, max_t, sigma, gamma, l_bound, u_bound, sig)
     result = minimize_scalar(func, bounds=(min_sig_bound, max_sig_bound),
                              method="bounded", options={"maxiter": 30})
     # Probability that neural response exists at given signal level
@@ -615,9 +641,9 @@ def analyze_psth(psth, n_sweeps, spont=None, sigma=None, gamma=None,
     total_prob = 1 - result.fun
     
     # Array of len max_t with probs of latency existing for each time idx
-    lats = nb_para_calc_lats(big_e, m_priors, event_counts, n_sweeps, 
-                             lat_start, lat_end, max_m, max_t, sigma, gamma, 
-                             l_bound, u_bound, signal)
+    lats = nb_para_calc_lats(
+        big_e, m_priors, interval_evidences, event_counts, n_sweeps, lat_start,
+        lat_end, max_m, max_t, sigma, gamma, l_bound, u_bound, signal)
     lats[np.isnan(lats)] = 0
     # Random cases may have rounding errors but should be treated as 1 or 0
     lats[1 < lats] = 1
@@ -628,10 +654,11 @@ def analyze_psth(psth, n_sweeps, spont=None, sigma=None, gamma=None,
         # Must re-calculate some variables to use entire PSTH sweep length
         max_t = len(psth)
         m_priors = nb_calc_m_priors(max_m, max_t, sigma, gamma)
-        big_e = nb_calc_big_e(m_priors, event_counts, n_sweeps, max_m, max_t, 
-                              sigma, gamma)
-        sdf = get_sdf(big_e, m_priors, event_counts, n_sweeps, max_m, max_t, 
-                      sigma, gamma, l_bound, u_bound)
+        interval_evidences = nb_precompute_interval_evidences(
+            event_counts, n_sweeps, max_t, sigma, gamma)
+        big_e = nb_calc_big_e(m_priors, interval_evidences, max_m, max_t)
+        sdf = get_sdf(big_e, m_priors, interval_evidences, event_counts,
+                      n_sweeps, max_m, max_t, sigma, gamma, l_bound, u_bound)
     else:
         sdf = None
     

--- a/src/stim_types/densetc.py
+++ b/src/stim_types/densetc.py
@@ -215,12 +215,33 @@ def _densetc_bw_loop(idx, file, total, use_f32, cfg, ic_pens=(),
     }
 
 
-def get_densetc_bb_lats(psth, n_sweeps, spont, return_sdf=True):
-    max_m = 10
-    lat_start = 1
-    bb_dict = bb.analyze_psth(psth, n_sweeps, spont, max_t=250, max_m=max_m,
-                              lat_start=lat_start, lat_end=150, l_bound=4,
-                              u_bound=max_m, return_sdf=return_sdf)
+def _densetc_signal_bounds(spont):
+    if spont < 25:
+        return 0.001, 0.025
+    if spont < 50:
+        return 0.025, 0.050
+    if spont < 100:
+        return 0.050, 0.100
+    return 0.100, 0.150
+
+
+def get_densetc_bb_lats(psth, n_sweeps, spont, return_sdf=True, *, max_t=250,
+                        max_m=10, lat_start=1, lat_end=150, l_bound=4,
+                        u_bound=None, min_sig_bound=None, max_sig_bound=None):
+    if u_bound is None:
+        u_bound = max_m
+    default_min_sig_bound, default_max_sig_bound = _densetc_signal_bounds(spont)
+    if min_sig_bound is None:
+        min_sig_bound = default_min_sig_bound
+    if max_sig_bound is None:
+        max_sig_bound = default_max_sig_bound
+
+    bb_dict = bb.analyze_psth(psth, n_sweeps, spont, max_t=max_t, max_m=max_m,
+                              lat_start=lat_start, lat_end=lat_end,
+                              l_bound=l_bound, u_bound=u_bound,
+                              min_sig_bound=min_sig_bound,
+                              max_sig_bound=max_sig_bound,
+                              return_sdf=return_sdf)
     sdf = bb_dict["sdf"]
     lats = np.nan_to_num(bb_dict["lats"][lat_start:], nan=0.0, posinf=1.0,
                          neginf=0.0)

--- a/src/stim_types/densetc.py
+++ b/src/stim_types/densetc.py
@@ -225,9 +225,49 @@ def _densetc_signal_bounds(spont):
     return 0.100, 0.150
 
 
+def _densetc_offset_from_sdf(sdf, onset, *, default_offset=300,
+                             offset_mean_atol=1e-2, offset_std_scale=1.0,
+                             offset_min_run=10, offset_adjust_ms=0):
+    d_sdf = np.diff(sdf)
+    d_sdf_range = np.ptp(d_sdf)
+    if d_sdf_range == 0:
+        return default_offset
+
+    d_norm_sdf = 2. * (d_sdf - np.min(d_sdf)) / d_sdf_range - 1
+    norm_mean = np.mean(d_norm_sdf)
+    norm_std = np.std(d_norm_sdf)
+    equals_mean = np.isclose(d_norm_sdf[onset:], norm_mean,
+                             atol=offset_mean_atol)
+    offsets = np.where(
+        d_norm_sdf[onset:] < (norm_mean - offset_std_scale * norm_std))[0]
+    if offsets.any():
+        potential_offsets = np.where(equals_mean[offsets[0]:] == 1)[0]
+        if potential_offsets.any():
+            seqs = 1 + np.where(np.diff(potential_offsets) != 1)[0]
+            offset_seqs = np.split(potential_offsets, seqs)
+            passing_offsets = np.where(
+                np.array([len(x) for x in offset_seqs]) >= offset_min_run)[0]
+            if passing_offsets.any():
+                offset = int(offset_seqs[passing_offsets[0]][0] +
+                             offsets[0] + onset)
+            else:
+                offset = int(offset_seqs[-1][0] + offsets[0] + onset)
+        else:
+            offset = int(offsets[0] + onset)
+    else:
+        offset = default_offset
+
+    if offset != default_offset and offset_adjust_ms:
+        offset = max(onset + 1, offset + offset_adjust_ms)
+        offset = min(default_offset, offset)
+    return offset
+
+
 def get_densetc_bb_lats(psth, n_sweeps, spont, return_sdf=True, *, max_t=250,
                         max_m=10, lat_start=1, lat_end=150, l_bound=4,
-                        u_bound=None, min_sig_bound=None, max_sig_bound=None):
+                        u_bound=None, min_sig_bound=None, max_sig_bound=None,
+                        offset_mean_atol=1e-2, offset_std_scale=1.0,
+                        offset_min_run=10, offset_adjust_ms=0):
     if u_bound is None:
         u_bound = max_m
     default_min_sig_bound, default_max_sig_bound = _densetc_signal_bounds(spont)
@@ -257,29 +297,14 @@ def get_densetc_bb_lats(psth, n_sweeps, spont, return_sdf=True, *, max_t=250,
     if (total_prob < 0.2) or (max_prob < 0.1):
         onset, peak, offset = 50, None, 300
     else:
-        d_sdf = np.diff(sdf)
-        d_norm_sdf = 2. * (d_sdf - np.min(d_sdf)) / np.ptp(d_sdf) - 1
-        norm_mean = np.mean(d_norm_sdf)
-        norm_std = np.std(d_norm_sdf)
-        equals_mean = np.isclose(d_norm_sdf[onset:], norm_mean, atol=1e-2)
-        offsets = np.where(d_norm_sdf[onset:] < (norm_mean - norm_std))[0]
-        if offsets.any():
-            potential_offsets = np.where(equals_mean[offsets[0]:] == 1)[0]
-            if potential_offsets.any():
-                seqs = 1 + np.where(np.diff(potential_offsets) != 1)[0]
-                offset_seqs = np.split(potential_offsets, seqs)
-                passing_offsets = np.where(
-                    np.array([len(x) for x in offset_seqs]) >= 10)[0]
-                if passing_offsets.any():
-                    offset = int(offset_seqs[passing_offsets[0]][0] +
-                                 offsets[0] + onset)
-                else:
-                    offset = int(offset_seqs[-1][0] + offsets[0] + onset)
-            else:
-                offset = int(offsets[0] + onset)
-        else:
+        if sdf is None:
             offset = 300
-
+        else:
+            offset = _densetc_offset_from_sdf(
+                sdf, onset, offset_mean_atol=offset_mean_atol,
+                offset_std_scale=offset_std_scale,
+                offset_min_run=offset_min_run,
+                offset_adjust_ms=offset_adjust_ms)
         peak = int(np.argmax(psth[onset:offset])) + onset
 
     return {

--- a/src/stim_types/densetc.py
+++ b/src/stim_types/densetc.py
@@ -222,15 +222,18 @@ def get_densetc_bb_lats(psth, n_sweeps, spont, return_sdf=True):
                               lat_start=lat_start, lat_end=150, l_bound=4,
                               u_bound=max_m, return_sdf=return_sdf)
     sdf = bb_dict["sdf"]
-    lats = bb_dict["lats"][lat_start:]
-    max_prob = np.amax(lats)
+    lats = np.nan_to_num(bb_dict["lats"][lat_start:], nan=0.0, posinf=1.0,
+                         neginf=0.0)
+    max_prob = float(np.amax(lats))
     onset = np.where(0.15 <= lats)[0]
     if onset.any():
         onset = int(onset[0] + lat_start)
     else:
         onset = int(np.argmax(lats) + lat_start)
 
-    if (bb_dict["total_prob"] < 0.2) or (max_prob < 0.1):
+    total_prob = float(np.nan_to_num(bb_dict["total_prob"], nan=0.0,
+                                     posinf=1.0, neginf=0.0))
+    if (total_prob < 0.2) or (max_prob < 0.1):
         onset, peak, offset = 50, None, 300
     else:
         d_sdf = np.diff(sdf)
@@ -265,7 +268,7 @@ def get_densetc_bb_lats(psth, n_sweeps, spont, return_sdf=True):
         "sdf": sdf,
         "lats": lats,
         "max_prob": max_prob,
-        "total_prob": bb_dict["total_prob"],
+        "total_prob": total_prob,
         "signal": bb_dict["signal"],
         "m_priors": bb_dict["m_priors"],
         "sigma": bb_dict["sigma"],

--- a/tests/test_bayesian_bins.py
+++ b/tests/test_bayesian_bins.py
@@ -18,7 +18,7 @@ from stim_types.densetc import get_densetc_bb_lats
 
 class BayesianBinsRegressionTests(unittest.TestCase):
     @staticmethod
-    def _load_demo_site_1():
+    def _load_demo_site(site_number):
         demo_file = (
             Path(__file__).resolve().parent.parent
             / "demo"
@@ -31,7 +31,9 @@ class BayesianBinsRegressionTests(unittest.TestCase):
             for key, value in obj.items()
             if "densetc_analysis" in key and "IC" not in key
         )
-        return next(doc for doc in docs.values() if doc.get("number") == 1)
+        return next(
+            doc for doc in docs.values() if doc.get("number") == site_number
+        )
 
     def test_nb_max_logsumexp_handles_all_negative_infinity(self):
         value = bb.nb_max_logsumexp(np.array([-np.inf, -np.inf], dtype=np.float64))
@@ -40,7 +42,7 @@ class BayesianBinsRegressionTests(unittest.TestCase):
         self.assertLess(value, 0)
 
     def test_demo_site_1_matches_frozen_latency_analysis(self):
-        site = self._load_demo_site_1()
+        site = self._load_demo_site(1)
 
         lat = get_densetc_bb_lats(
             np.array(site["psth"], dtype=np.int64),
@@ -55,6 +57,21 @@ class BayesianBinsRegressionTests(unittest.TestCase):
         self.assertTrue(np.isfinite(lat["lats"]).all())
         self.assertAlmostEqual(lat["max_prob"], site["bb_latency_prob"], places=6)
         self.assertAlmostEqual(lat["total_prob"], site["bb_total_lat_prob"], places=6)
+
+    def test_demo_unknown_site_stays_unknown(self):
+        site = self._load_demo_site(39)
+
+        lat = get_densetc_bb_lats(
+            np.array(site["psth"], dtype=np.int64),
+            n_sweeps=1296,
+            spont=site["spont_firing_rate_hz"],
+            return_sdf=True,
+        )
+
+        self.assertEqual(lat["onset"], site["onset_ms"])
+        self.assertIsNone(lat["peak"])
+        self.assertEqual(lat["offset"], site["offset_ms"])
+        self.assertTrue(np.isfinite(lat["lats"]).all())
 
 
 if __name__ == "__main__":

--- a/tests/test_bayesian_bins.py
+++ b/tests/test_bayesian_bins.py
@@ -1,0 +1,61 @@
+import json
+import math
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+os.makedirs(Path(tempfile.gettempdir()) / "ads-mpl-tests", exist_ok=True)
+os.environ.setdefault(
+    "MPLCONFIGDIR", str(Path(tempfile.gettempdir()) / "ads-mpl-tests")
+)
+
+import bayesian_bins as bb
+from stim_types.densetc import get_densetc_bb_lats
+
+
+class BayesianBinsRegressionTests(unittest.TestCase):
+    @staticmethod
+    def _load_demo_site_1():
+        demo_file = (
+            Path(__file__).resolve().parent.parent
+            / "demo"
+            / "output"
+            / "analyzed_demo.json"
+        )
+        obj = json.loads(demo_file.read_text())
+        docs = next(
+            value
+            for key, value in obj.items()
+            if "densetc_analysis" in key and "IC" not in key
+        )
+        return next(doc for doc in docs.values() if doc.get("number") == 1)
+
+    def test_nb_max_logsumexp_handles_all_negative_infinity(self):
+        value = bb.nb_max_logsumexp(np.array([-np.inf, -np.inf], dtype=np.float64))
+
+        self.assertTrue(math.isinf(value))
+        self.assertLess(value, 0)
+
+    def test_demo_site_1_matches_frozen_latency_analysis(self):
+        site = self._load_demo_site_1()
+
+        lat = get_densetc_bb_lats(
+            np.array(site["psth"], dtype=np.int64),
+            n_sweeps=1296,
+            spont=site["spont_firing_rate_hz"],
+            return_sdf=True,
+        )
+
+        self.assertEqual(lat["onset"], site["onset_ms"])
+        self.assertEqual(lat["peak"], site["peak_ms"])
+        self.assertEqual(lat["offset"], site["offset_ms"])
+        self.assertTrue(np.isfinite(lat["lats"]).all())
+        self.assertAlmostEqual(lat["max_prob"], site["bb_latency_prob"], places=6)
+        self.assertAlmostEqual(lat["total_prob"], site["bb_total_lat_prob"], places=6)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_bayesian_bins.py
+++ b/tests/test_bayesian_bins.py
@@ -73,6 +73,24 @@ class BayesianBinsRegressionTests(unittest.TestCase):
         self.assertEqual(lat["offset"], site["offset_ms"])
         self.assertTrue(np.isfinite(lat["lats"]).all())
 
+    def test_prior_exponent_fit_returns_finite_bounded_values(self):
+        site = self._load_demo_site(1)
+
+        fit = bb.fit_prior_exponents(
+            np.array(site["psth"], dtype=np.int64),
+            n_sweeps=1296,
+            max_t=40,
+            max_m=3,
+            maxiter=5,
+        )
+
+        self.assertTrue(np.isfinite(fit["sigma"]))
+        self.assertTrue(np.isfinite(fit["gamma"]))
+        self.assertGreaterEqual(fit["sigma"], 0.001)
+        self.assertLessEqual(fit["sigma"], 300)
+        self.assertGreaterEqual(fit["gamma"], 1)
+        self.assertLessEqual(fit["gamma"], 300)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Running analysis on modern dependencies and after refactoring showed errors in latency estimation. Digging in to the issue revealed that the original use of `fastmath` was shaky, and some change in numba/numpy/scipy resulted in `nan` instead of `-inf`, which in turn produced nonsense latencies downstream.

Since the code was being updated anyway, used this opportunity to improve the file altogether. There's now a small testing suite (comparing results to the previously working/known auto-analysis in v1.0 of the program in `demo/demo_analysis.json`) and speed benchmarking. Benchmarking showed adding cached signal-dependent betainc logs and interval beta evidence produced about a 7x improvement.

Additional refactor moved auditory neurophys specific details out of `bayesian_bins.py` (now passed in as args). Also now have a set of params for controlling offset determination. Testing showed that the heuristic values provided in the densetc analysis code are better than wide params or optimizer derived, but should values ever need to be changed, it is now much more reasonable to do so.

Added the original C++ simplex optimizer for beta prior exponents as an optional tool also.

New documentation for everything provided in `docs/bayesian_bins.md` and updated `docs/testing.md`.

Closes #70 