### PR TITLE
Fix OCR bootstrap

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -65,6 +65,13 @@ uv tool run --with 'nox[uv]' nox -s smoke
 uv tool run --with 'nox[uv]' nox -s tests
 ```
 
+For a local editable environment:
+
+```bash
+python -m pip install -e '.[test]'
+python -m pytest
+```
+
 ## Slow Bayesian Bins Regression
 
 Run this before changing Bayesian Bins, DenseTC latency defaults, or SDF offset

--- a/noxfile.py
+++ b/noxfile.py
@@ -21,8 +21,7 @@ def _run_smoke(session: nox.Session) -> None:
 
 @nox.session(name="tests", python=SUPPORTED_PYTHONS)
 def tests(session: nox.Session) -> None:
-    session.install("-e", ".")
-    session.install("pytest")
+    session.install("-e", ".[test]")
     session.run("pytest")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,11 @@ dependencies = [
   "tinydb",
 ]
 
+[project.optional-dependencies]
+test = [
+  "pytest",
+]
+
 [project.scripts]
 map-analysis = "map_analysis:main"
 

--- a/src/dialogs.py
+++ b/src/dialogs.py
@@ -32,18 +32,31 @@ def _hidden_root():
     """A withdrawn Tk root, destroyed on exit. Backbone of every primitive."""
     root = tk.Tk()
     root.withdraw()
+    _drain_tk(root)
     try:
         yield root
     finally:
+        _drain_tk(root)
         try:
             root.destroy()
         except Exception:
             pass
+        _drain_tk(root)
 
 
-def _dialog_kwargs(kwargs):
+def _drain_tk(root):
+    try:
+        root.update_idletasks()
+        root.update()
+    except TclError:
+        pass
+
+
+def _dialog_kwargs(kwargs, parent=None):
     dialog_kwargs = dict(kwargs)
     dialog_kwargs.setdefault("initialdir", str(_LAST_DIALOG_DIR))
+    if parent is not None:
+        dialog_kwargs.setdefault("parent", parent)
     return dialog_kwargs
 
 
@@ -56,6 +69,23 @@ def _remember_dialog_path(path, *, is_folder=False):
     picked = Path(path)
     _LAST_DIALOG_DIR = picked if is_folder else picked.parent
 
+
+def _run_file_dialog(dialog_func, kwargs, *, is_folder=False):
+    parent = kwargs.get("parent")
+    if parent is None:
+        with _hidden_root() as root:
+            path = dialog_func(**_dialog_kwargs(kwargs))
+            _drain_tk(root)
+    else:
+        _drain_tk(parent)
+        try:
+            path = dialog_func(**_dialog_kwargs(kwargs, parent))
+        finally:
+            _drain_tk(parent)
+
+    _remember_dialog_path(path, is_folder=is_folder)
+    return path
+
 # -- file / folder primitives ---------------------------------------------
 
 def get_folder(**kwargs):
@@ -64,40 +94,32 @@ def get_folder(**kwargs):
     string on cancel. (Trailing slash preserved for callers that build
     paths by string concat; TODO pathlib follow-up.)
     """
-    with _hidden_root():
-        folder = filedialog.askdirectory(**_dialog_kwargs(kwargs))
-    _remember_dialog_path(folder, is_folder=True)
+    folder = _run_file_dialog(filedialog.askdirectory, kwargs, is_folder=True)
     return (folder + "/") if folder else ""
 
 def get_file(**kwargs):
     """File-open picker. Returns path string, or empty string on cancel."""
-    with _hidden_root():
-        path = filedialog.askopenfilename(**_dialog_kwargs(kwargs))
-    _remember_dialog_path(path)
-    return path
+    return _run_file_dialog(filedialog.askopenfilename, kwargs)
 
 def save_file(**kwargs):
     """File-save picker. Returns path string, or empty string on cancel."""
-    with _hidden_root():
-        path = filedialog.asksaveasfilename(**_dialog_kwargs(kwargs))
-    _remember_dialog_path(path)
-    return path
+    return _run_file_dialog(filedialog.asksaveasfilename, kwargs)
 
 # -- simple prompt primitives ---------------------------------------------
 
 def ask_string(title, prompt):
     """Single-line text prompt. Returns the string, or None on cancel."""
-    with _hidden_root():
-        return simpledialog.askstring(title, prompt)
+    with _hidden_root() as root:
+        return simpledialog.askstring(title, prompt, parent=root)
 
 def confirm(title, message):
     """Yes/No box. Returns bool."""
-    with _hidden_root():
-        return messagebox.askyesno(title, message)
+    with _hidden_root() as root:
+        return messagebox.askyesno(title, message, parent=root)
 
 def show_error(title, message):
-    with _hidden_root():
-        messagebox.showerror(title, message)
+    with _hidden_root() as root:
+        messagebox.showerror(title, message, parent=root)
 
 # -- subprocess focus pump -------------------------------------------------
 

--- a/src/digit_ocr.py
+++ b/src/digit_ocr.py
@@ -63,13 +63,14 @@ class DigitOCR:
         return instance
 
     @classmethod
-    def bootstrap(cls, number_crops, required_conf=0.85):
+    def bootstrap(cls, number_crops, required_conf=0.995):
         """
         If you don't have a font file, create templates from input images.
         
-        Attempts to match against any existing templates first.
-        Any digit that doesn't match with at least required_conf receives
-        a user-input label and becomes that digit's template.
+        Attempts to match exact duplicates against existing templates first.
+        Any digit that doesn't match with at least required_conf receives a
+        user-input label and becomes that digit's template. Bootstrap uses a
+        high default threshold because false matches skip template creation.
         """
         import matplotlib.pyplot as plt
 
@@ -84,45 +85,125 @@ class DigitOCR:
         print(f"Extracted {len(all_digits)} individual digit images.")
         print("Label each unique digit:  0-9 = digit,  s = skip\n")
 
-        for digit_binary in all_digits:
-            normed = cls._normalize(digit_binary)
+        fig = None
+        ax = None
+        try:
+            for digit_binary in all_digits:
+                normed = cls._normalize(digit_binary)
 
-            if any(t is not None for t in instance._working_templates.values()):
-                _, best_score = instance._match_single(normed)
-                if best_score >= required_conf:
-                    match_count += 1
+                if any(t is not None for t in instance._working_templates.values()):
+                    _, best_score = instance._match_single(normed)
+                    if best_score >= required_conf:
+                        match_count += 1
+                        continue
+
+                display = cv2.resize(
+                    255 - digit_binary, (0, 0),
+                    fx=4, fy=4, interpolation=cv2.INTER_NEAREST,
+                )
+                if fig is None:
+                    fig, ax = plt.subplots(figsize=(2.5, 3))
+                    cls._configure_prompt_window(fig)
+                    cls._hide_prompt_toolbar(fig)
+                cls._draw_prompt_digit(fig, ax, display)
+
+                while not ((resp := input("  Label (0-9 / s): ")) == "s"
+                           or (resp.isdigit() and 0 <= int(resp) <= 9)):
                     continue
 
-            display = cv2.resize(
-                255 - digit_binary, (0, 0),
-                fx=4, fy=4, interpolation=cv2.INTER_NEAREST,
-            )
-            fig, ax = plt.subplots(figsize=(2.5, 3))
-            ax.imshow(display, cmap="gray", vmin=0, vmax=255)
-            ax.set_title("What digit?")
-            ax.axis("off")
-            fig.tight_layout()
-            plt.show(block=False)
-            fig.canvas.draw()
-            fig.canvas.flush_events()
-
-            while not ((resp := input("  Label (0-9 / s): ")) == "s" 
-                       or (resp.isdigit() and 0 <= int(resp) <= 9)):
-                continue
-            plt.close(fig)
-
-            if resp == "s":
-                continue
-            if resp.isdigit() and 0 <= int(resp) <= 9:
-                instance._working_templates[int(resp)] = normed
-                labeled_count += 1
-                instance._compile_templates()
+                if resp == "s":
+                    continue
+                if resp.isdigit() and 0 <= int(resp) <= 9:
+                    instance._working_templates[int(resp)] = normed
+                    labeled_count += 1
+                    instance._compile_templates()
+        finally:
+            if fig is not None:
+                plt.close(fig)
 
         instance.validate()
         instance._compile_templates()
         print(f"\nDone: {labeled_count} labeled, {match_count} template-matched.")
         instance.print_summary()
         return instance
+
+    @staticmethod
+    def _draw_prompt_digit(fig, ax, display):
+        import matplotlib.pyplot as plt
+
+        ax.clear()
+        image = ax.imshow(display, cmap="gray", vmin=0, vmax=255)
+        image.get_cursor_data = lambda _event: None
+        ax.format_coord = lambda _x, _y: ""
+        ax.set_title("What digit?")
+        ax.axis("off")
+        fig.tight_layout()
+        DigitOCR._disable_prompt_status_text(fig)
+        plt.show(block=False)
+        fig.canvas.draw()
+        fig.canvas.flush_events()
+
+    @staticmethod
+    def _hide_prompt_toolbar(fig):
+        manager = getattr(fig.canvas, "manager", None)
+        toolbar = getattr(manager, "toolbar", None)
+        if toolbar is None:
+            return
+
+        for method_name in ("pack_forget", "hide"):
+            method = getattr(toolbar, method_name, None)
+            if method is None:
+                continue
+            try:
+                method()
+                return
+            except Exception:
+                pass
+
+        if hasattr(toolbar, "setVisible"):
+            try:
+                toolbar.setVisible(False)
+            except Exception:
+                pass
+
+    @staticmethod
+    def _configure_prompt_window(fig):
+        manager = getattr(fig.canvas, "manager", None)
+        if manager is not None and hasattr(manager, "set_window_title"):
+            manager.set_window_title("Digit OCR Bootstrap")
+
+        window = getattr(manager, "window", None)
+        if window is None:
+            return
+
+        # TkAgg. Reusing the figure avoids repeated focus stealing; these
+        # window hints keep it visible and pinned to a stable screen location.
+        if hasattr(window, "wm_geometry"):
+            window.wm_geometry("+80+80")
+        elif hasattr(window, "setGeometry"):
+            window.setGeometry(80, 80, 260, 320)
+
+        for attr_name in ("attributes", "wm_attributes"):
+            attr = getattr(window, attr_name, None)
+            if attr is None:
+                continue
+            try:
+                attr("-topmost", True)
+                break
+            except Exception:
+                pass
+
+    @staticmethod
+    def _disable_prompt_status_text(fig):
+        manager = getattr(fig.canvas, "manager", None)
+        toolbar = getattr(manager, "toolbar", None)
+        if toolbar is None or not hasattr(toolbar, "set_message"):
+            return
+        try:
+            toolbar.set_message("")
+            toolbar.set_message = lambda _message: None
+        except Exception:
+            pass
 
     # ────────────────────────────────────────────────────────────
     #  Persistence

--- a/src/voronoi_picker.py
+++ b/src/voronoi_picker.py
@@ -16,12 +16,14 @@ from __future__ import annotations
 import csv
 from os import PathLike
 import tkinter as tk
-from tkinter import filedialog, messagebox
+from tkinter import messagebox
 from typing import Iterable, Optional
 
 import numpy as np
 from scipy.spatial import QhullError, Voronoi
 from shapely.geometry import Polygon, box
+
+from dialogs import get_file, save_file
 
 
 _BACKGROUND = "#d8d8d8"
@@ -575,7 +577,8 @@ class Picker:
             return
         if not messagebox.askyesno(
                 "Clear buffer points?",
-                "Remove all buffer points from this picker?"):
+                "Remove all buffer points from this picker?",
+                parent=self.root):
             return
         self._push_history()
         self.buffer_points = np.empty((0, 2), dtype=np.float64)
@@ -604,9 +607,10 @@ class Picker:
         return "break"
 
     def load_points_dialog(self, _event=None):
-        path = filedialog.askopenfilename(
+        path = get_file(
             title="Load buffer points",
             filetypes=(("CSV files", "*.csv"), ("All files", "*.*")),
+            parent=self.root,
         )
         if not path:
             return "break"
@@ -614,7 +618,7 @@ class Picker:
         try:
             loaded_points = load_buffer_points_csv(path)
         except (OSError, ValueError) as exc:
-            messagebox.showerror("Could not load points", str(exc))
+            messagebox.showerror("Could not load points", str(exc), parent=self.root)
             return "break"
 
         replace = True
@@ -622,6 +626,7 @@ class Picker:
             response = messagebox.askyesnocancel(
                 "Load buffer points",
                 "Replace current buffer points? Choose No to append them.",
+                parent=self.root,
             )
             if response is None:
                 return "break"
@@ -641,10 +646,11 @@ class Picker:
         return "break"
 
     def export_points_dialog(self, _event=None) -> bool | str:
-        path = filedialog.asksaveasfilename(
+        path = save_file(
             title="Export buffer points",
             defaultextension=".csv",
             filetypes=(("CSV files", "*.csv"), ("All files", "*.*")),
+            parent=self.root,
         )
         if not path:
             return "break"
@@ -652,12 +658,13 @@ class Picker:
         try:
             save_buffer_points_csv(self.buffer_points, path)
         except OSError as exc:
-            messagebox.showerror("Could not export points", str(exc))
+            messagebox.showerror("Could not export points", str(exc), parent=self.root)
             return "break"
 
         messagebox.showinfo(
             "Export complete",
             f"Saved {len(self.buffer_points)} points.",
+            parent=self.root,
         )
         return True
 

--- a/tests/test_dialogs.py
+++ b/tests/test_dialogs.py
@@ -1,0 +1,77 @@
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import dialogs
+
+
+class FakeRoot:
+    def __init__(self):
+        self.idle_updates = 0
+        self.updates = 0
+
+    def update_idletasks(self):
+        self.idle_updates += 1
+
+    def update(self):
+        self.updates += 1
+
+
+class FakeHiddenRoot(FakeRoot):
+    def __init__(self):
+        super().__init__()
+        self.withdrawn = False
+        self.destroyed = False
+
+    def withdraw(self):
+        self.withdrawn = True
+
+    def destroy(self):
+        self.destroyed = True
+
+
+class DialogWrapperTests(unittest.TestCase):
+    def test_get_file_does_not_parent_to_hidden_root(self):
+        hidden_root = FakeHiddenRoot()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            chosen_path = str(Path(tmpdir) / "map.png")
+            with patch.object(dialogs.tk, "Tk", return_value=hidden_root), patch.object(
+                dialogs.filedialog,
+                "askopenfilename",
+                return_value=chosen_path,
+            ) as askopen:
+                result = dialogs.get_file(title="Pick file")
+
+        askopen.assert_called_once()
+        self.assertNotIn("parent", askopen.call_args.kwargs)
+        self.assertTrue(hidden_root.withdrawn)
+        self.assertTrue(hidden_root.destroyed)
+        self.assertEqual(result, chosen_path)
+
+    def test_get_file_reuses_supplied_parent(self):
+        parent = FakeRoot()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            chosen_path = str(Path(tmpdir) / "points.csv")
+            with patch.object(dialogs.tk, "Tk") as tk_ctor, patch.object(
+                dialogs.filedialog,
+                "askopenfilename",
+                return_value=chosen_path,
+            ) as askopen:
+                result = dialogs.get_file(title="Pick file", parent=parent)
+
+        tk_ctor.assert_not_called()
+        askopen.assert_called_once()
+        self.assertEqual(askopen.call_args.kwargs["parent"], parent)
+        self.assertEqual(result, chosen_path)
+        self.assertGreaterEqual(parent.idle_updates, 2)
+        self.assertGreaterEqual(parent.updates, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_digit_ocr.py
+++ b/tests/test_digit_ocr.py
@@ -1,0 +1,55 @@
+import os
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+os.environ.setdefault("MPLCONFIGDIR", tempfile.gettempdir())
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import cv2
+
+from digit_ocr import DigitOCR
+from subject_analysis import extract_number_crops
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class DigitOCRBootstrapTests(unittest.TestCase):
+    def test_bootstrap_demo_digits_does_not_skip_three(self):
+        numbers_image = cv2.imread(
+            str(ROOT / "demo" / "img" / "demo_num.png"),
+            cv2.IMREAD_GRAYSCALE,
+        )
+        mask_image = cv2.imread(
+            str(ROOT / "demo" / "img" / "demo_msk.png"),
+            cv2.IMREAD_GRAYSCALE,
+        )
+        _, crops = extract_number_crops(numbers_image, mask_image)
+        labels = iter(["4", "9", "2", "1", "6", "5", "0", "7", "3", "8"])
+
+        with redirect_stdout(StringIO()), patch.object(plt, "show"), patch(
+            "builtins.input",
+            side_effect=lambda _prompt: next(labels),
+        ):
+            ocr = DigitOCR.bootstrap(crops)
+
+        missing = [
+            digit for digit, template in ocr._working_templates.items()
+            if template is None
+        ]
+        self.assertEqual(missing, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Found bootstrapping template from images resulted in `3` being skipped; was a false-positive match with `2` due to background driving high similarity match with "existing template".

Fix increased the confidence required for pattern matching during bootstrap.

Applied some misc. updates along the way:
- Added pytest to the venv proper
- Fixed ghost tk dialogs from masking cursor input over screen areas where they were
- Unified voronoi pickers file dialogs with the existing solution