### PR TITLE
fix: noiseburst filename regex

### DIFF
--- a/src/brainware.py
+++ b/src/brainware.py
@@ -19,6 +19,7 @@ __all__ = [
 _FILENAME_PATTERNS = {
     "src": [
         (r"[0-9]{3}(?=\.src)",   r"(?<=#)[0-9]{3}"),
+        (r"[0-9]{1,3}(?=\.src)", r"(?<=#)[0-9]{3}"),
         (r"[0-9]{1,3}(?=\.src)", r"[0-9]{3}(?=e)"),
         (r"[0-9]{1,3}(?=\.src)", r"(?<=_)[0-9]{3}"),
     ],
@@ -35,8 +36,6 @@ def _parse_filename(filename):
     Match `filename` against the known Brainware filenaming conventions.
     Returns (electrode_int, penetration_int). Raises ValueError if the
     extension is unrecognized or no pattern pair matches.
-    TODO NB example in CLI project prompts, "bb_noise_train#001G1_7.src",
-    doens't match here -- fix it!
     """
     ext = filename[-3:]
     if ext not in _FILENAME_PATTERNS:
@@ -56,6 +55,7 @@ def get_map_number(filename):
     Penetration and electrode -> flat map number, parsed from a Brainware
     filename. Some known conventions:
     - DenseTC_..._JRAC#001G_RZ5-1_007.src
+    - bb_noise_train#001G1_7.src
     - foo_001e1.src
     - foo_001_1.src
     - naive2dense_001e1.f32

--- a/tests/test_brainware.py
+++ b/tests/test_brainware.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 from neo.io.brainwaresrcio import BrainwareSrcIO
 
+from brainware import get_map_number, get_penetration_number
 from brainware import get_spike_dict, prettify_spike_dict
 
 
@@ -16,6 +17,12 @@ def _fake_spiketrain(times):
 
 
 class BrainwareParsingTests(unittest.TestCase):
+    def test_noiseburst_src_filename_parses_penetration_and_electrode(self):
+        filename = "bb_noise_train#001G1_7.src"
+
+        self.assertEqual(get_penetration_number(filename), 1)
+        self.assertEqual(get_map_number(filename), 1)
+
     def test_get_spike_dict_falls_back_to_non_unassigned_group_spikes(self):
         blk = SimpleNamespace(
             file_origin="demo.src",


### PR DESCRIPTION
Penetration number regex pattern didn't match existing noiseburst filename example. Small update fixes it.